### PR TITLE
Foundation hardening: env validation, Stripe webhook verification, Convex Auth, CSP, hardened Elysia

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,25 @@
-# Convex
+# ─── Required in production ────────────────────────────────────
+NODE_ENV=development
+
+# Convex — from `bunx convex dev` output
 CONVEX_DEPLOYMENT=
 NEXT_PUBLIC_CONVEX_URL=
 
-# Stripe
+# Web app origin (used by API CORS + CSP connect-src)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Stripe — required for the webhook handler
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 
-# Optional model keys
-OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
+# Elysia gateway
+API_BEARER_TOKEN=
+API_PORT=3001
+
+# ─── Optional ──────────────────────────────────────────────────
+WEBHOOK_TOLERANCE_SECONDS=300
+LOG_LEVEL=info
+
+# ⚠️ NEVER commit a real .env file. For Convex secrets, use
+#    `bunx convex env set <NAME> <VALUE>` — they live in the Convex
+#    dashboard, not in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this template are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-05-12
+
+First tagged cut of the hardened foundation. Safe to fork for production.
+
+### Added
+- `@acme/config`: Zod env schema with `NODE_ENV`-conditional required fields, a Node-runtime loader (`dotenv` in non-prod, frozen `env` export), and a separate Convex-side loader (`apps/convex/convex/_lib/env.ts`).
+- Convex Auth wiring via `@convex-dev/auth` (Password provider), `SITE_URL` parsed/validated in `auth.config.ts` (https globally, `http://localhost` only locally), and a `requireUser` / `requireUserDoc` guard with `users.me` and `users.updateProfile` example queries.
+- Convex schema additions: `users` (with `stripeCustomerId`, `plan`, `planStatus`, `planUpdatedAt`) plus indexes; `processedStripeEvents` for webhook idempotency; auth tables from `@convex-dev/auth/server`.
+- Stripe webhook handler at `POST /stripe/webhook`:
+  - Async signature verification via `stripe.webhooks.constructEventAsync` (Convex Web-Crypto runtime).
+  - Idempotency marker recorded **after** successful processing so failed applies are retried by Stripe.
+  - `applySubscriptionChange` throws on unmapped customers so the webhook returns non-2xx and Stripe retries instead of drifting state.
+- Next.js Edge middleware with per-request CSP nonces, `'strict-dynamic'`, dev-only `'unsafe-eval'`, and `upgrade-insecure-requests` gated to production. Static security headers (`X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, conditional HSTS) in `next.config.ts`.
+- Hardened Elysia gateway (`apps/api`):
+  - `pino` structured logger with header redaction.
+  - Security headers, CORS, bearer guard with `timingSafeEqual` comparison.
+  - In-memory rate limit on `/protected/*` with opt-in `trustProxy`, integer-validated `max`/`windowMs`, and a periodic sweep so the key store can't grow unboundedly.
+  - Graceful shutdown on `SIGINT`/`SIGTERM`.
+- `tooling/scripts/check-versions.ts` extended with `config`, `convex`, `api`, and `web` workspace pin enforcement; `devDependencies` lookups are now strict per category.
+- `.env.example` rewritten with the full foundation env surface; `apps/web/.env.local.example` for public envs.
+- README: "Scaling the rate limiter" section documenting the Upstash/Redis swap path.
+
+### Tests
+- `packages/config` Zod schema tests (defaults, prod-required fields, coercion).
+- `apps/convex` `requireUser` and `users.me` / `users.updateProfile` tests via `convex-test`.
+- `apps/convex` Stripe webhook tests: missing/invalid signature → 400, valid signature applies plan, replay is idempotent, `subscription.deleted` clears the plan.
+- `apps/web` middleware CSP tests including production-vs-development directive presence regressions.
+
+### Fixed
+- `mapStatus` preserves numeric error codes and maps `UNAUTHORIZED` → 401, `FORBIDDEN` → 403.
+- Root `RootLayout` no longer reads `headers()`, dropping the spurious dynamic-rendering force.
+- `apps/web/middleware.ts` declares its own `zod` dependency so CI typecheck doesn't depend on hoisting.
+
+[0.1.0]: https://github.com/yabasha/composable-ai-stack/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ If you want a dedicated webhook gateway with custom middleware/rate limiting, us
 
 ---
 
+## Scaling the rate limiter
+
+`apps/api` ships an in-memory rate limiter (`apps/api/src/middleware/rate-limit.ts`).
+It tracks request counts in a single-process `Map`. For multi-worker or multi-instance
+deployments, replace the backing store with Redis or Upstash:
+
+1. Install: `bun add --filter=api @upstash/ratelimit @upstash/redis`
+2. Swap the `Map` in `rate-limit.ts` for an Upstash `Ratelimit` instance.
+3. Set `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in `.env`.
+
+The middleware exposes `X-RateLimit-Backend: memory` so you can verify which store
+is in use at runtime.
+
+---
+
 ## Scripts (root)
 - `bun run dev` — dev for all apps
 - `bun run dev:web` — Next.js only

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,10 +11,14 @@
   },
   "dependencies": {
     "@acme/config": "workspace:*",
-    "elysia": "1.4.22"
+    "@elysiajs/bearer": "1.4.4",
+    "@elysiajs/cors": "1.4.2",
+    "elysia": "1.4.22",
+    "pino": "10.3.1"
   },
   "devDependencies": {
     "@types/bun": "1.2.5",
+    "pino-pretty": "13.1.3",
     "typescript": "^5.5.0"
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "lint": "echo \"(optional) add eslint\""
   },
   "dependencies": {
+    "@acme/config": "workspace:*",
     "elysia": "1.4.22"
   },
   "devDependencies": {

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,0 +1,1 @@
+export { env } from "@acme/config";

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,10 +7,15 @@ import { rateLimit } from "./middleware/rate-limit";
 import { bearerGuard } from "./middleware/bearer-guard";
 
 function mapStatus(code: string | number): number {
+  if (typeof code === "number") return code;
   switch (code) {
     case "VALIDATION":
     case "PARSE":
       return 400;
+    case "UNAUTHORIZED":
+      return 401;
+    case "FORBIDDEN":
+      return 403;
     case "NOT_FOUND":
       return 404;
     default:

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,61 @@
 import { Elysia } from "elysia";
+import { cors } from "@elysiajs/cors";
+import { env } from "./env";
+import { logger } from "./logger";
+import { securityHeaders } from "./middleware/security-headers";
+import { rateLimit } from "./middleware/rate-limit";
+import { bearerGuard } from "./middleware/bearer-guard";
 
-/**
- * Optional API gateway.
- * Use this when you want a classic HTTP surface with middleware, webhooks, or non-Convex clients.
- */
+function mapStatus(code: string | number): number {
+  switch (code) {
+    case "VALIDATION":
+    case "PARSE":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    default:
+      return 500;
+  }
+}
+
 const app = new Elysia()
+  .use(securityHeaders)
+  .use(
+    cors({
+      origin: env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+      credentials: true,
+      methods: ["GET", "POST", "OPTIONS"],
+      allowedHeaders: ["authorization", "content-type"]
+    })
+  )
+  .onRequest(({ request }) => {
+    logger.info({ method: request.method, url: request.url }, "request");
+  })
+  .onError(({ error, code, set }) => {
+    logger.error({ err: error, code }, "error");
+    set.status = mapStatus(code);
+    return {
+      error: {
+        code,
+        message: env.NODE_ENV === "production" ? "internal error" : String((error as Error)?.message ?? error)
+      }
+    };
+  })
   .get("/health", () => ({ ok: true }))
-  .listen(3001);
+  .group("/protected", (a) =>
+    a
+      .use(bearerGuard)
+      .use(rateLimit({ max: 60, windowMs: 60_000 }))
+      .get("/me", () => ({ ok: true }))
+  )
+  .listen({ port: env.API_PORT, hostname: "0.0.0.0" });
 
-console.log(`API listening on http://localhost:${app.server?.port}`);
+logger.info({ port: env.API_PORT }, "api listening");
+
+const drain = async () => {
+  logger.info("draining…");
+  await app.stop();
+  process.exit(0);
+};
+process.on("SIGTERM", drain);
+process.on("SIGINT", drain);

--- a/apps/api/src/logger.ts
+++ b/apps/api/src/logger.ts
@@ -1,0 +1,20 @@
+import pino from "pino";
+import { env } from "./env";
+
+const isProd = env.NODE_ENV === "production";
+
+export const logger = pino({
+  level: env.LOG_LEVEL,
+  redact: {
+    paths: [
+      "req.headers.authorization",
+      "req.headers.cookie",
+      "*.password",
+      "*.token"
+    ],
+    censor: "[redacted]"
+  },
+  transport: isProd
+    ? undefined
+    : { target: "pino-pretty", options: { colorize: true, translateTime: "SYS:HH:MM:ss.l" } }
+});

--- a/apps/api/src/middleware/bearer-guard.ts
+++ b/apps/api/src/middleware/bearer-guard.ts
@@ -12,7 +12,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 
 export const bearerGuard = new Elysia({ name: "bearer-guard" })
   .use(bearer())
-  .onBeforeHandle(({ bearer, set }) => {
+  .onBeforeHandle({ as: "global" }, ({ bearer, set }) => {
     if (!env.API_BEARER_TOKEN) {
       set.status = 500;
       return { error: { code: "API_BEARER_TOKEN_NOT_CONFIGURED" } };

--- a/apps/api/src/middleware/bearer-guard.ts
+++ b/apps/api/src/middleware/bearer-guard.ts
@@ -1,0 +1,26 @@
+import { Elysia } from "elysia";
+import { bearer } from "@elysiajs/bearer";
+import { timingSafeEqual } from "node:crypto";
+import { env } from "../env";
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+export const bearerGuard = new Elysia({ name: "bearer-guard" })
+  .use(bearer())
+  .onBeforeHandle(({ bearer, set }) => {
+    if (!env.API_BEARER_TOKEN) {
+      set.status = 500;
+      return { error: { code: "API_BEARER_TOKEN_NOT_CONFIGURED" } };
+    }
+    if (!bearer || !constantTimeEqual(bearer, env.API_BEARER_TOKEN)) {
+      set.status = 401;
+      set.headers ??= {};
+      set.headers["www-authenticate"] = "Bearer";
+      return { error: { code: "UNAUTHORIZED" } };
+    }
+  });

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,48 @@
+// In-memory rate limiter. Replace with Redis/Upstash for multi-worker deployments.
+// See README → "Scaling the rate limiter".
+import { Elysia } from "elysia";
+
+type Bucket = { count: number; resetAt: number };
+
+export type RateLimitOptions = {
+  max?: number;
+  windowMs?: number;
+};
+
+export function rateLimit(opts: RateLimitOptions = {}) {
+  const max = opts.max ?? 60;
+  const windowMs = opts.windowMs ?? 60_000;
+  const store = new Map<string, Bucket>();
+
+  return new Elysia({ name: `rate-limit:${max}:${windowMs}` }).onBeforeHandle(
+    ({ request, set }) => {
+      const auth = request.headers.get("authorization");
+      const bearer = auth?.toLowerCase().startsWith("bearer ") ? auth.slice(7) : null;
+      const xff = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+      const key = bearer ?? xff ?? "anonymous";
+
+      const now = Date.now();
+      const bucket = store.get(key);
+      if (!bucket || bucket.resetAt <= now) {
+        store.set(key, { count: 1, resetAt: now + windowMs });
+        set.headers ??= {};
+        set.headers["x-ratelimit-limit"] = String(max);
+        set.headers["x-ratelimit-remaining"] = String(max - 1);
+        set.headers["x-ratelimit-reset"] = String(now + windowMs);
+        set.headers["x-ratelimit-backend"] = "memory";
+        return;
+      }
+      bucket.count += 1;
+      set.headers ??= {};
+      set.headers["x-ratelimit-limit"] = String(max);
+      set.headers["x-ratelimit-remaining"] = String(Math.max(0, max - bucket.count));
+      set.headers["x-ratelimit-reset"] = String(bucket.resetAt);
+      set.headers["x-ratelimit-backend"] = "memory";
+      if (bucket.count > max) {
+        set.status = 429;
+        set.headers["retry-after"] = String(Math.ceil((bucket.resetAt - now) / 1000));
+        return { error: { code: "RATE_LIMITED", message: "too many requests" } };
+      }
+    }
+  );
+}

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -16,8 +16,19 @@ export type RateLimitOptions = {
 export function rateLimit(opts: RateLimitOptions = {}) {
   const max = opts.max ?? 60;
   const windowMs = opts.windowMs ?? 60_000;
+  if (!Number.isInteger(max) || max < 1) {
+    throw new RangeError("rateLimit: `max` must be an integer >= 1");
+  }
+  if (!Number.isInteger(windowMs) || windowMs < 1) {
+    throw new RangeError("rateLimit: `windowMs` must be an integer >= 1");
+  }
   const trustProxy = opts.trustProxy ?? false;
   const store = new Map<string, Bucket>();
+  // Periodic sweep so one-off keys (spoofed bearers, rotating IPs) don't grow
+  // the store unboundedly between accesses. Cleared on shutdown by GC when the
+  // Elysia instance is collected.
+  const SWEEP_EVERY_WRITES = 500;
+  let writesSinceSweep = 0;
 
   return new Elysia({ name: `rate-limit:${max}:${windowMs}` }).onBeforeHandle(
     { as: "global" },
@@ -30,6 +41,12 @@ export function rateLimit(opts: RateLimitOptions = {}) {
       const key = bearer ?? xff ?? "anonymous";
 
       const now = Date.now();
+      if (++writesSinceSweep >= SWEEP_EVERY_WRITES) {
+        writesSinceSweep = 0;
+        for (const [k, v] of store) {
+          if (v.resetAt <= now) store.delete(k);
+        }
+      }
       const bucket = store.get(key);
       if (!bucket || bucket.resetAt <= now) {
         store.set(key, { count: 1, resetAt: now + windowMs });

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -7,11 +7,16 @@ type Bucket = { count: number; resetAt: number };
 export type RateLimitOptions = {
   max?: number;
   windowMs?: number;
+  // Set to true only when this process sits behind a trusted reverse proxy
+  // that rewrites `x-forwarded-for`. Raw values are client-controllable and
+  // would otherwise let callers spoof a different bucket on each request.
+  trustProxy?: boolean;
 };
 
 export function rateLimit(opts: RateLimitOptions = {}) {
   const max = opts.max ?? 60;
   const windowMs = opts.windowMs ?? 60_000;
+  const trustProxy = opts.trustProxy ?? false;
   const store = new Map<string, Bucket>();
 
   return new Elysia({ name: `rate-limit:${max}:${windowMs}` }).onBeforeHandle(
@@ -19,7 +24,9 @@ export function rateLimit(opts: RateLimitOptions = {}) {
     ({ request, set }) => {
       const auth = request.headers.get("authorization");
       const bearer = auth?.toLowerCase().startsWith("bearer ") ? auth.slice(7) : null;
-      const xff = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+      const xff = trustProxy
+        ? request.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+        : null;
       const key = bearer ?? xff ?? "anonymous";
 
       const now = Date.now();

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -15,6 +15,7 @@ export function rateLimit(opts: RateLimitOptions = {}) {
   const store = new Map<string, Bucket>();
 
   return new Elysia({ name: `rate-limit:${max}:${windowMs}` }).onBeforeHandle(
+    { as: "global" },
     ({ request, set }) => {
       const auth = request.headers.get("authorization");
       const bearer = auth?.toLowerCase().startsWith("bearer ") ? auth.slice(7) : null;

--- a/apps/api/src/middleware/security-headers.ts
+++ b/apps/api/src/middleware/security-headers.ts
@@ -4,6 +4,7 @@ import { env } from "../env";
 const isProd = env.NODE_ENV === "production";
 
 export const securityHeaders = new Elysia({ name: "security-headers" }).onAfterHandle(
+  { as: "global" },
   ({ set }) => {
     const headers = (set.headers ??= {});
     headers["x-content-type-options"] = "nosniff";

--- a/apps/api/src/middleware/security-headers.ts
+++ b/apps/api/src/middleware/security-headers.ts
@@ -1,0 +1,17 @@
+import { Elysia } from "elysia";
+import { env } from "../env";
+
+const isProd = env.NODE_ENV === "production";
+
+export const securityHeaders = new Elysia({ name: "security-headers" }).onAfterHandle(
+  ({ set }) => {
+    const headers = (set.headers ??= {});
+    headers["x-content-type-options"] = "nosniff";
+    headers["x-frame-options"] = "DENY";
+    headers["referrer-policy"] = "strict-origin-when-cross-origin";
+    headers["permissions-policy"] = "camera=(), microphone=(), geolocation=(), interest-cohort=()";
+    if (isProd) {
+      headers["strict-transport-security"] = "max-age=63072000; includeSubDomains; preload";
+    }
+  }
+);

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -4,7 +4,11 @@
     "outDir": "dist",
     "types": [
       "@types/bun"
-    ]
+    ],
+    "paths": {
+      "@acme/config": ["../../packages/config/src/index.ts"],
+      "@acme/config/schema": ["../../packages/config/src/schema.ts"]
+    }
   },
   "include": [
     "src"

--- a/apps/convex/convex/_generated/api.d.ts
+++ b/apps/convex/convex/_generated/api.d.ts
@@ -8,7 +8,10 @@
  * @module
  */
 
+import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as stripe from "../stripe.js";
+import type * as users from "../users.js";
 
 import type {
   ApiFromModules,
@@ -17,7 +20,10 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
   http: typeof http;
+  stripe: typeof stripe;
+  users: typeof users;
 }>;
 
 /**

--- a/apps/convex/convex/_generated/api.d.ts
+++ b/apps/convex/convex/_generated/api.d.ts
@@ -1,3 +1,9 @@
+/**
+ * NOTE: Hand-edited stop-gap. `convex codegen` was not runnable locally in
+ * this worktree (no CONVEX_DEPLOYMENT). The next real codegen run will
+ * regenerate this file from the function modules and may produce harmless
+ * formatting/import-style differences. Functionality is preserved.
+ */
 /* eslint-disable */
 /**
  * Generated `api` utility.

--- a/apps/convex/convex/_lib/env.ts
+++ b/apps/convex/convex/_lib/env.ts
@@ -1,0 +1,4 @@
+import { parseEnv, type Env } from "@acme/config/schema";
+
+const mode = process.env.NODE_ENV ?? "development";
+export const env: Env = Object.freeze(parseEnv(process.env, mode));

--- a/apps/convex/convex/_lib/stripe.ts
+++ b/apps/convex/convex/_lib/stripe.ts
@@ -1,0 +1,18 @@
+import Stripe from "stripe";
+import { env } from "./env";
+
+// Pinned to the SDK's current default for the pinned `stripe` package version.
+// When bumping the stripe dep, review the changelog and update this constant.
+const API_VERSION = "2026-04-22.dahlia" as const;
+
+let cached: Stripe | undefined;
+
+export function getStripe(): Stripe {
+  if (!cached) {
+    if (!env.STRIPE_SECRET_KEY) {
+      throw new Error("STRIPE_SECRET_KEY is required to use the Stripe client");
+    }
+    cached = new Stripe(env.STRIPE_SECRET_KEY, { apiVersion: API_VERSION });
+  }
+  return cached;
+}

--- a/apps/convex/convex/_lib/test-modules.ts
+++ b/apps/convex/convex/_lib/test-modules.ts
@@ -7,10 +7,7 @@ export const testModules = {
   "./http.ts": () => import("../http"),
   "./schema.ts": () => import("../schema"),
   "./users.ts": () => import("../users"),
-  // @ts-ignore Task 13 will create `../stripe`; until then the import fails at
-  // runtime and the catch yields an empty module, which is fine for tests that
-  // don't touch Stripe.
-  "./stripe.ts": () => import("../stripe").catch(() => ({})),
+  "./stripe.ts": () => import("../stripe"),
   "./_generated/api.js": () => import("../_generated/api"),
   "./_generated/server.js": () => import("../_generated/server")
 };

--- a/apps/convex/convex/_lib/test-modules.ts
+++ b/apps/convex/convex/_lib/test-modules.ts
@@ -1,0 +1,16 @@
+// Bun's test runner doesn't implement `import.meta.glob` (Vite-only), so we
+// supply the modules map convex-test needs by hand. Include every Convex
+// function module plus the generated namespaces so convex-test can derive its
+// prefix. Add new modules here when adding new Convex files under `convex/`.
+export const testModules = {
+  "./auth.ts": () => import("../auth"),
+  "./http.ts": () => import("../http"),
+  "./schema.ts": () => import("../schema"),
+  "./users.ts": () => import("../users"),
+  // @ts-ignore Task 13 will create `../stripe`; until then the import fails at
+  // runtime and the catch yields an empty module, which is fine for tests that
+  // don't touch Stripe.
+  "./stripe.ts": () => import("../stripe").catch(() => ({})),
+  "./_generated/api.js": () => import("../_generated/api"),
+  "./_generated/server.js": () => import("../_generated/server")
+};

--- a/apps/convex/convex/_lib/withUser.test.ts
+++ b/apps/convex/convex/_lib/withUser.test.ts
@@ -2,29 +2,16 @@ import { test, expect, describe } from "bun:test";
 import { convexTest } from "convex-test";
 import schema from "../schema";
 import { api } from "../_generated/api";
-
-// `convex-test` normally discovers modules via Vite's `import.meta.glob`, which
-// Bun's test runner does not implement. We provide the module map manually so
-// the same tests work under `bun test`. Keys must be paths relative to this
-// file and must include the `_generated` directory so convex-test can derive
-// the module prefix.
-const modules = {
-  "../auth.ts": () => import("../auth"),
-  "../http.ts": () => import("../http"),
-  "../schema.ts": () => import("../schema"),
-  "../users.ts": () => import("../users"),
-  "../_generated/api.js": () => import("../_generated/api.js"),
-  "../_generated/server.js": () => import("../_generated/server.js")
-};
+import { testModules } from "./test-modules";
 
 describe("requireUser", () => {
   test("users.me throws when unauthenticated", async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, testModules);
     await expect(t.query(api.users.me, {})).rejects.toThrow(/UNAUTHENTICATED/);
   });
 
   test("users.me returns the user doc when authenticated", async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, testModules);
     const userId = await t.run(async (ctx) => {
       return ctx.db.insert("users", {
         email: "alice@example.com",
@@ -38,7 +25,7 @@ describe("requireUser", () => {
   });
 
   test("users.updateProfile writes name for the authenticated user", async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, testModules);
     const userId = await t.run(async (ctx) => {
       return ctx.db.insert("users", {
         email: "alice@example.com",
@@ -53,7 +40,7 @@ describe("requireUser", () => {
   });
 
   test("users.updateProfile throws when unauthenticated", async () => {
-    const t = convexTest(schema, modules);
+    const t = convexTest(schema, testModules);
     await expect(t.mutation(api.users.updateProfile, { name: "x" })).rejects.toThrow(/UNAUTHENTICATED/);
   });
 });

--- a/apps/convex/convex/_lib/withUser.test.ts
+++ b/apps/convex/convex/_lib/withUser.test.ts
@@ -1,0 +1,59 @@
+import { test, expect, describe } from "bun:test";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+
+// `convex-test` normally discovers modules via Vite's `import.meta.glob`, which
+// Bun's test runner does not implement. We provide the module map manually so
+// the same tests work under `bun test`. Keys must be paths relative to this
+// file and must include the `_generated` directory so convex-test can derive
+// the module prefix.
+const modules = {
+  "../auth.ts": () => import("../auth"),
+  "../http.ts": () => import("../http"),
+  "../schema.ts": () => import("../schema"),
+  "../users.ts": () => import("../users"),
+  "../_generated/api.js": () => import("../_generated/api.js"),
+  "../_generated/server.js": () => import("../_generated/server.js")
+};
+
+describe("requireUser", () => {
+  test("users.me throws when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(t.query(api.users.me, {})).rejects.toThrow(/UNAUTHENTICATED/);
+  });
+
+  test("users.me returns the user doc when authenticated", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        email: "alice@example.com",
+        tokenIdentifier: "convex:alice",
+        createdAt: Date.now()
+      });
+    });
+    const asAlice = t.withIdentity({ tokenIdentifier: "convex:alice", subject: userId });
+    const me = await asAlice.query(api.users.me, {});
+    expect(me?.email).toBe("alice@example.com");
+  });
+
+  test("users.updateProfile writes name for the authenticated user", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        email: "alice@example.com",
+        tokenIdentifier: "convex:alice",
+        createdAt: Date.now()
+      });
+    });
+    const asAlice = t.withIdentity({ tokenIdentifier: "convex:alice", subject: userId });
+    await asAlice.mutation(api.users.updateProfile, { name: "Alice Smith" });
+    const after = await t.run((ctx) => ctx.db.get(userId));
+    expect(after?.name).toBe("Alice Smith");
+  });
+
+  test("users.updateProfile throws when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(t.mutation(api.users.updateProfile, { name: "x" })).rejects.toThrow(/UNAUTHENTICATED/);
+  });
+});

--- a/apps/convex/convex/_lib/withUser.ts
+++ b/apps/convex/convex/_lib/withUser.ts
@@ -8,10 +8,10 @@ type Ctx = QueryCtx | MutationCtx;
 /**
  * Returns the authenticated user's id, or throws `UNAUTHENTICATED`.
  *
- * Looks at Convex Auth's session first, then falls back to
- * `ctx.auth.getUserIdentity()` + the `users.by_token` index. The fallback path
- * is what makes this guard testable via `convex-test`'s `withIdentity` helper,
- * which injects an identity without spinning up a real Convex Auth session.
+ * In production, `getAuthUserId(ctx)` always returns for an authenticated
+ * caller and the by_token fallback below is unused. The fallback exists so
+ * `convex-test`'s `withIdentity` helper can drive this guard without spinning
+ * up real Convex Auth sessions.
  */
 export async function requireUser(ctx: Ctx): Promise<Id<"users">> {
   const direct = await getAuthUserId(ctx);

--- a/apps/convex/convex/_lib/withUser.ts
+++ b/apps/convex/convex/_lib/withUser.ts
@@ -1,0 +1,37 @@
+import { ConvexError } from "convex/values";
+import type { QueryCtx, MutationCtx } from "../_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import type { Id } from "../_generated/dataModel";
+
+type Ctx = QueryCtx | MutationCtx;
+
+/**
+ * Returns the authenticated user's id, or throws `UNAUTHENTICATED`.
+ *
+ * Looks at Convex Auth's session first, then falls back to
+ * `ctx.auth.getUserIdentity()` + the `users.by_token` index. The fallback path
+ * is what makes this guard testable via `convex-test`'s `withIdentity` helper,
+ * which injects an identity without spinning up a real Convex Auth session.
+ */
+export async function requireUser(ctx: Ctx): Promise<Id<"users">> {
+  const direct = await getAuthUserId(ctx);
+  if (direct) return direct;
+
+  const identity = await ctx.auth.getUserIdentity();
+  if (identity?.tokenIdentifier) {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.tokenIdentifier))
+      .first();
+    if (user) return user._id;
+  }
+
+  throw new ConvexError({ code: "UNAUTHENTICATED" });
+}
+
+export async function requireUserDoc(ctx: Ctx) {
+  const userId = await requireUser(ctx);
+  const user = await ctx.db.get(userId);
+  if (!user) throw new ConvexError({ code: "USER_NOT_FOUND" });
+  return user;
+}

--- a/apps/convex/convex/auth.config.ts
+++ b/apps/convex/convex/auth.config.ts
@@ -1,10 +1,19 @@
-// SITE_URL is set via `bunx convex env set SITE_URL <url>` and lives in the
-// Convex dashboard, not in @acme/config (which never reaches Convex's runtime
-// for SITE_URL specifically — it's read here only).
+// SITE_URL is set per Convex deployment via `bunx convex env set SITE_URL <url>`
+// and lives in the Convex dashboard, not in @acme/config (it's only read here
+// and never reaches Next/Elysia/Worker).
+const domain = process.env.SITE_URL;
+if (!domain) {
+  throw new Error(
+    "SITE_URL is not set on this Convex deployment. " +
+      "Run: bunx convex env set SITE_URL <https-url-of-your-deployment>"
+  );
+}
+
 export default {
   providers: [
     {
-      domain: process.env.SITE_URL!,
+      domain,
+      // Required literal for Convex Auth (identifies the JWT audience as the Convex backend).
       applicationID: "convex"
     }
   ]

--- a/apps/convex/convex/auth.config.ts
+++ b/apps/convex/convex/auth.config.ts
@@ -1,13 +1,30 @@
 // SITE_URL is set per Convex deployment via `bunx convex env set SITE_URL <url>`
 // and lives in the Convex dashboard, not in @acme/config (it's only read here
 // and never reaches Next/Elysia/Worker).
-const domain = process.env.SITE_URL;
-if (!domain) {
+const rawSiteUrl = process.env.SITE_URL;
+if (!rawSiteUrl) {
   throw new Error(
     "SITE_URL is not set on this Convex deployment. " +
       "Run: bunx convex env set SITE_URL <https-url-of-your-deployment>"
   );
 }
+
+let parsedSiteUrl: URL;
+try {
+  parsedSiteUrl = new URL(rawSiteUrl);
+} catch {
+  throw new Error(`SITE_URL must be a valid absolute URL (got: ${rawSiteUrl})`);
+}
+
+if (parsedSiteUrl.protocol !== "https:" && parsedSiteUrl.hostname !== "localhost") {
+  throw new Error(
+    `SITE_URL must use https outside local development (got: ${parsedSiteUrl.protocol}//${parsedSiteUrl.host})`
+  );
+}
+
+// Normalize: use the origin (protocol + host[:port]) so trailing paths/slashes
+// can't silently change the JWT audience.
+const domain = parsedSiteUrl.origin;
 
 export default {
   providers: [

--- a/apps/convex/convex/auth.config.ts
+++ b/apps/convex/convex/auth.config.ts
@@ -1,0 +1,11 @@
+// SITE_URL is set via `bunx convex env set SITE_URL <url>` and lives in the
+// Convex dashboard, not in @acme/config (which never reaches Convex's runtime
+// for SITE_URL specifically — it's read here only).
+export default {
+  providers: [
+    {
+      domain: process.env.SITE_URL!,
+      applicationID: "convex"
+    }
+  ]
+};

--- a/apps/convex/convex/auth.config.ts
+++ b/apps/convex/convex/auth.config.ts
@@ -16,9 +16,12 @@ try {
   throw new Error(`SITE_URL must be a valid absolute URL (got: ${rawSiteUrl})`);
 }
 
-if (parsedSiteUrl.protocol !== "https:" && parsedSiteUrl.hostname !== "localhost") {
+const isHttps = parsedSiteUrl.protocol === "https:";
+const isLocalHttp =
+  parsedSiteUrl.hostname === "localhost" && parsedSiteUrl.protocol === "http:";
+if (!isHttps && !isLocalHttp) {
   throw new Error(
-    `SITE_URL must use https outside local development (got: ${parsedSiteUrl.protocol}//${parsedSiteUrl.host})`
+    `SITE_URL must be https, or http://localhost for local development (got: ${parsedSiteUrl.protocol}//${parsedSiteUrl.host})`
   );
 }
 

--- a/apps/convex/convex/auth.ts
+++ b/apps/convex/convex/auth.ts
@@ -1,0 +1,11 @@
+import { convexAuth } from "@convex-dev/auth/server";
+import { Password } from "@convex-dev/auth/providers/Password";
+
+/**
+ * Convex Auth wiring. The Password provider is the only built-in for the
+ * template; add GitHub/Google/etc. by following:
+ *   https://labs.convex.dev/auth/config/oauth
+ */
+export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
+  providers: [Password]
+});

--- a/apps/convex/convex/http.test.ts
+++ b/apps/convex/convex/http.test.ts
@@ -6,9 +6,11 @@ import { testModules } from "./_lib/test-modules";
 
 const SECRET = "whsec_test_secret_value";
 
-function signedRequest(body: string, secret: string): Request {
+async function signedRequest(body: string, secret: string): Promise<Request> {
   const stripe = new Stripe("sk_test_x", { apiVersion: "2026-04-22.dahlia" });
-  const header = stripe.webhooks.generateTestHeaderString({ payload: body, secret });
+  // Bun resolves stripe's "worker" export, which only provides SubtleCrypto
+  // (async-only). Use the async helper to avoid the sync HMAC error.
+  const header = await stripe.webhooks.generateTestHeaderStringAsync({ payload: body, secret });
   return new Request("https://convex.example/stripe/webhook", {
     method: "POST",
     headers: { "stripe-signature": header, "content-type": "application/json" },
@@ -50,7 +52,7 @@ describe("POST /stripe/webhook", () => {
   test("returns 400 when the signature is invalid", async () => {
     const t = convexTest(schema, testModules);
     const body = baseEvent();
-    const req = signedRequest(body, "whsec_wrong_secret");
+    const req = await signedRequest(body, "whsec_wrong_secret");
     const res = await t.fetch("/stripe/webhook", {
       method: "POST",
       headers: Object.fromEntries(req.headers.entries()),
@@ -69,7 +71,7 @@ describe("POST /stripe/webhook", () => {
       })
     );
     const body = baseEvent();
-    const req = signedRequest(body, SECRET);
+    const req = await signedRequest(body, SECRET);
     const res = await t.fetch("/stripe/webhook", {
       method: "POST",
       headers: Object.fromEntries(req.headers.entries()),
@@ -96,13 +98,13 @@ describe("POST /stripe/webhook", () => {
       })
     );
     const body = baseEvent();
-    const req1 = signedRequest(body, SECRET);
+    const req1 = await signedRequest(body, SECRET);
     await t.fetch("/stripe/webhook", {
       method: "POST",
       headers: Object.fromEntries(req1.headers.entries()),
       body
     });
-    const req2 = signedRequest(body, SECRET);
+    const req2 = await signedRequest(body, SECRET);
     const res2 = await t.fetch("/stripe/webhook", {
       method: "POST",
       headers: Object.fromEntries(req2.headers.entries()),
@@ -123,7 +125,7 @@ describe("POST /stripe/webhook", () => {
       })
     );
     const body = baseEvent({ id: "evt_test_2", type: "customer.subscription.deleted" });
-    const req = signedRequest(body, SECRET);
+    const req = await signedRequest(body, SECRET);
     const res = await t.fetch("/stripe/webhook", {
       method: "POST",
       headers: Object.fromEntries(req.headers.entries()),

--- a/apps/convex/convex/http.test.ts
+++ b/apps/convex/convex/http.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, beforeEach } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { convexTest } from "convex-test";
 import Stripe from "stripe";
 import schema from "./schema";
@@ -33,10 +33,23 @@ const baseEvent = (overrides: Record<string, unknown> = {}) =>
   });
 
 describe("POST /stripe/webhook", () => {
+  const prevEnv = {
+    STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+    NEXT_PUBLIC_CONVEX_URL: process.env.NEXT_PUBLIC_CONVEX_URL
+  };
+
   beforeEach(() => {
     process.env.STRIPE_WEBHOOK_SECRET = SECRET;
     process.env.STRIPE_SECRET_KEY = "sk_test_x";
     process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(prevEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
   });
 
   test("returns 400 when Stripe-Signature is missing", async () => {

--- a/apps/convex/convex/http.test.ts
+++ b/apps/convex/convex/http.test.ts
@@ -1,0 +1,141 @@
+import { test, expect, describe, beforeEach } from "bun:test";
+import { convexTest } from "convex-test";
+import Stripe from "stripe";
+import schema from "./schema";
+import { testModules } from "./_lib/test-modules";
+
+const SECRET = "whsec_test_secret_value";
+
+function signedRequest(body: string, secret: string): Request {
+  const stripe = new Stripe("sk_test_x", { apiVersion: "2026-04-22.dahlia" });
+  const header = stripe.webhooks.generateTestHeaderString({ payload: body, secret });
+  return new Request("https://convex.example/stripe/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": header, "content-type": "application/json" },
+    body
+  });
+}
+
+const baseEvent = (overrides: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    id: "evt_test_1",
+    type: "customer.subscription.updated",
+    data: {
+      object: {
+        customer: "cus_test_1",
+        status: "active",
+        items: { data: [{ price: { id: "price_x", lookup_key: "pro_monthly" } }] }
+      }
+    },
+    ...overrides
+  });
+
+describe("POST /stripe/webhook", () => {
+  beforeEach(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = SECRET;
+    process.env.STRIPE_SECRET_KEY = "sk_test_x";
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+  });
+
+  test("returns 400 when Stripe-Signature is missing", async () => {
+    const t = convexTest(schema, testModules);
+    const res = await t.fetch("/stripe/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: baseEvent()
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when the signature is invalid", async () => {
+    const t = convexTest(schema, testModules);
+    const body = baseEvent();
+    const req = signedRequest(body, "whsec_wrong_secret");
+    const res = await t.fetch("/stripe/webhook", {
+      method: "POST",
+      headers: Object.fromEntries(req.headers.entries()),
+      body
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 200 on valid signature and updates the user plan", async () => {
+    const t = convexTest(schema, testModules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        email: "alice@example.com",
+        stripeCustomerId: "cus_test_1",
+        createdAt: Date.now()
+      })
+    );
+    const body = baseEvent();
+    const req = signedRequest(body, SECRET);
+    const res = await t.fetch("/stripe/webhook", {
+      method: "POST",
+      headers: Object.fromEntries(req.headers.entries()),
+      body
+    });
+    expect(res.status).toBe(200);
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("by_stripe_customer", (q) => q.eq("stripeCustomerId", "cus_test_1"))
+        .first()
+    );
+    expect(user?.planStatus).toBe("active");
+    expect(user?.plan).toBe("pro_monthly");
+  });
+
+  test("replay of the same event id is idempotent", async () => {
+    const t = convexTest(schema, testModules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        email: "alice@example.com",
+        stripeCustomerId: "cus_test_1",
+        createdAt: Date.now()
+      })
+    );
+    const body = baseEvent();
+    const req1 = signedRequest(body, SECRET);
+    await t.fetch("/stripe/webhook", {
+      method: "POST",
+      headers: Object.fromEntries(req1.headers.entries()),
+      body
+    });
+    const req2 = signedRequest(body, SECRET);
+    const res2 = await t.fetch("/stripe/webhook", {
+      method: "POST",
+      headers: Object.fromEntries(req2.headers.entries()),
+      body
+    });
+    expect(res2.status).toBe(200);
+    const events = await t.run((ctx) => ctx.db.query("processedStripeEvents").collect());
+    expect(events.length).toBe(1);
+  });
+
+  test("customer.subscription.deleted sets planStatus to canceled", async () => {
+    const t = convexTest(schema, testModules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        email: "alice@example.com",
+        stripeCustomerId: "cus_test_1",
+        createdAt: Date.now()
+      })
+    );
+    const body = baseEvent({ id: "evt_test_2", type: "customer.subscription.deleted" });
+    const req = signedRequest(body, SECRET);
+    const res = await t.fetch("/stripe/webhook", {
+      method: "POST",
+      headers: Object.fromEntries(req.headers.entries()),
+      body
+    });
+    expect(res.status).toBe(200);
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("by_stripe_customer", (q) => q.eq("stripeCustomerId", "cus_test_1"))
+        .first()
+    );
+    expect(user?.planStatus).toBe("canceled");
+  });
+});

--- a/apps/convex/convex/http.test.ts
+++ b/apps/convex/convex/http.test.ts
@@ -121,6 +121,8 @@ describe("POST /stripe/webhook", () => {
       ctx.db.insert("users", {
         email: "alice@example.com",
         stripeCustomerId: "cus_test_1",
+        planStatus: "active",
+        plan: "pro_monthly",
         createdAt: Date.now()
       })
     );

--- a/apps/convex/convex/http.test.ts
+++ b/apps/convex/convex/http.test.ts
@@ -139,5 +139,6 @@ describe("POST /stripe/webhook", () => {
         .first()
     );
     expect(user?.planStatus).toBe("canceled");
+    expect(user?.plan).toBeUndefined();
   });
 });

--- a/apps/convex/convex/http.ts
+++ b/apps/convex/convex/http.ts
@@ -1,16 +1,84 @@
 import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { auth } from "./auth";
+import { getStripe } from "./_lib/stripe";
+import { env } from "./_lib/env";
+import type Stripe from "stripe";
 
 const http = httpRouter();
 
-// Example placeholder webhook route.
-// Replace handler with Stripe verification + event handling.
+// Mount Convex Auth routes (`/api/auth/*`).
+auth.addHttpRoutes(http);
+
 http.route({
   path: "/stripe/webhook",
   method: "POST",
-  handler: httpAction(async (_ctx, _request) => {
-    return new Response("ok", { status: 200 });
-  }),
+  handler: httpAction(async (ctx, request) => {
+    if (!env.STRIPE_WEBHOOK_SECRET) {
+      return new Response("STRIPE_WEBHOOK_SECRET not configured", { status: 500 });
+    }
+
+    const body = await request.text();
+    const sig = request.headers.get("stripe-signature");
+    if (!sig) return new Response("missing signature", { status: 400 });
+
+    const stripe = getStripe();
+    let event: Stripe.Event;
+    try {
+      // Convex runs httpActions in a Web-style runtime with SubtleCrypto, so use
+      // the async verifier to avoid sync-HMAC errors.
+      event = await stripe.webhooks.constructEventAsync(
+        body,
+        sig,
+        env.STRIPE_WEBHOOK_SECRET,
+        env.WEBHOOK_TOLERANCE_SECONDS
+      );
+    } catch {
+      return new Response("invalid signature", { status: 400 });
+    }
+
+    const fresh = await ctx.runMutation(internal.stripe.recordEvent, {
+      eventId: event.id,
+      type: event.type
+    });
+    if (!fresh) {
+      return new Response(JSON.stringify({ received: true, duplicate: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    }
+
+    switch (event.type) {
+      case "customer.subscription.created":
+      case "customer.subscription.updated": {
+        const sub = event.data.object as Stripe.Subscription;
+        const item = sub.items.data[0]?.price;
+        await ctx.runMutation(internal.stripe.applySubscriptionChange, {
+          stripeCustomerId: typeof sub.customer === "string" ? sub.customer : sub.customer.id,
+          status: sub.status,
+          plan: item?.lookup_key ?? item?.id ?? null
+        });
+        break;
+      }
+      case "customer.subscription.deleted": {
+        const sub = event.data.object as Stripe.Subscription;
+        await ctx.runMutation(internal.stripe.applySubscriptionChange, {
+          stripeCustomerId: typeof sub.customer === "string" ? sub.customer : sub.customer.id,
+          status: "canceled",
+          plan: null
+        });
+        break;
+      }
+      default:
+        console.info("unhandled stripe event type", event.type);
+    }
+
+    return new Response(JSON.stringify({ received: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  })
 });
 
 export default http;

--- a/apps/convex/convex/http.ts
+++ b/apps/convex/convex/http.ts
@@ -38,11 +38,13 @@ http.route({
       return new Response("invalid signature", { status: 400 });
     }
 
-    const fresh = await ctx.runMutation(internal.stripe.recordEvent, {
-      eventId: event.id,
-      type: event.type
+    // Check for replay BEFORE applying side effects. The marker is written at
+    // the end so a failed apply leaves the event eligible for Stripe retries
+    // instead of being silently swallowed.
+    const alreadyProcessed = await ctx.runQuery(internal.stripe.hasProcessedEvent, {
+      eventId: event.id
     });
-    if (!fresh) {
+    if (alreadyProcessed) {
       return new Response(JSON.stringify({ received: true, duplicate: true }), {
         status: 200,
         headers: { "content-type": "application/json" }
@@ -73,6 +75,12 @@ http.route({
       default:
         console.info("unhandled stripe event type", event.type);
     }
+
+    // Record only after the apply path completed successfully.
+    await ctx.runMutation(internal.stripe.recordEvent, {
+      eventId: event.id,
+      type: event.type
+    });
 
     return new Response(JSON.stringify({ received: true }), {
       status: 200,

--- a/apps/convex/convex/schema.ts
+++ b/apps/convex/convex/schema.ts
@@ -1,16 +1,36 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
+import { authTables } from "@convex-dev/auth/server";
 
-/**
- * Minimal schema to track membership plan status.
- * Expand as needed (workspaces, roles, billing, etc.)
- */
 export default defineSchema({
+  ...authTables,
+
   users: defineTable({
     email: v.string(),
+    tokenIdentifier: v.optional(v.string()),
+    name: v.optional(v.string()),
+    image: v.optional(v.string()),
+
+    // Convex Auth optional user fields (kept for compatibility with authTables).
+    phone: v.optional(v.string()),
+    emailVerificationTime: v.optional(v.number()),
+    phoneVerificationTime: v.optional(v.number()),
+    isAnonymous: v.optional(v.boolean()),
+
     stripeCustomerId: v.optional(v.string()),
-    plan: v.optional(v.string()),          // e.g. "free" | "pro"
-    planStatus: v.optional(v.string()),    // e.g. "active" | "past_due" | "canceled"
+    plan: v.optional(v.string()),
+    planStatus: v.optional(v.string()),
+    planUpdatedAt: v.optional(v.number()),
+
     createdAt: v.number()
-  }).index("by_email", ["email"])
+  })
+    .index("by_email", ["email"])
+    .index("by_token", ["tokenIdentifier"])
+    .index("by_stripe_customer", ["stripeCustomerId"]),
+
+  processedStripeEvents: defineTable({
+    eventId: v.string(),
+    type: v.string(),
+    processedAt: v.number()
+  }).index("by_eventId", ["eventId"])
 });

--- a/apps/convex/convex/schema.ts
+++ b/apps/convex/convex/schema.ts
@@ -6,7 +6,7 @@ export default defineSchema({
   ...authTables,
 
   users: defineTable({
-    email: v.string(),
+    email: v.string(), // tightened from authTables (optional); required for Password+Stripe flow
     tokenIdentifier: v.optional(v.string()),
     name: v.optional(v.string()),
     image: v.optional(v.string()),
@@ -32,5 +32,5 @@ export default defineSchema({
     eventId: v.string(),
     type: v.string(),
     processedAt: v.number()
-  }).index("by_eventId", ["eventId"])
+  }).index("by_event_id", ["eventId"])
 });

--- a/apps/convex/convex/stripe.ts
+++ b/apps/convex/convex/stripe.ts
@@ -1,9 +1,25 @@
-import { internalMutation } from "./_generated/server";
+import { internalMutation, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
- * Records a Stripe event ID. Returns true if newly recorded, false if duplicate
- * (the caller should treat false as "already processed; skip work").
+ * Read-only duplicate check, called BEFORE applying side effects so a failed
+ * apply can still be retried by Stripe (the marker is only written after
+ * `recordEvent` runs at the end of successful processing).
+ */
+export const hasProcessedEvent = internalQuery({
+  args: { eventId: v.string() },
+  handler: async (ctx, { eventId }) => {
+    const existing = await ctx.db
+      .query("processedStripeEvents")
+      .withIndex("by_event_id", (q) => q.eq("eventId", eventId))
+      .first();
+    return existing !== null;
+  }
+});
+
+/**
+ * Records a Stripe event ID after successful processing. Returns true if newly
+ * recorded, false if a concurrent delivery beat us to it.
  *
  * Convex has no unique-index constraint. This is a read-then-insert; concurrent
  * deliveries of the same event could race. Stripe retries are sequential in

--- a/apps/convex/convex/stripe.ts
+++ b/apps/convex/convex/stripe.ts
@@ -54,7 +54,13 @@ export const applySubscriptionChange = internalMutation({
       .query("users")
       .withIndex("by_stripe_customer", (q) => q.eq("stripeCustomerId", stripeCustomerId))
       .first();
-    if (!user) return;
+    if (!user) {
+      // Fail loud so the webhook returns non-2xx and Stripe retries. Silent
+      // no-op would let the account drift permanently out of sync with Stripe.
+      throw new Error(
+        `No user linked to Stripe customer ${stripeCustomerId}`
+      );
+    }
     await ctx.db.patch(user._id, {
       planStatus: status,
       plan: plan ?? undefined,

--- a/apps/convex/convex/stripe.ts
+++ b/apps/convex/convex/stripe.ts
@@ -1,0 +1,48 @@
+import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * Records a Stripe event ID. Returns true if newly recorded, false if duplicate
+ * (the caller should treat false as "already processed; skip work").
+ *
+ * Convex has no unique-index constraint. This is a read-then-insert; concurrent
+ * deliveries of the same event could race. Stripe retries are sequential in
+ * practice, so this is acceptable for a template. Forks needing strict
+ * uniqueness should layer their own pattern.
+ */
+export const recordEvent = internalMutation({
+  args: { eventId: v.string(), type: v.string() },
+  handler: async (ctx, { eventId, type }) => {
+    const existing = await ctx.db
+      .query("processedStripeEvents")
+      .withIndex("by_event_id", (q) => q.eq("eventId", eventId))
+      .first();
+    if (existing) return false;
+    await ctx.db.insert("processedStripeEvents", {
+      eventId,
+      type,
+      processedAt: Date.now()
+    });
+    return true;
+  }
+});
+
+export const applySubscriptionChange = internalMutation({
+  args: {
+    stripeCustomerId: v.string(),
+    status: v.string(),
+    plan: v.union(v.string(), v.null())
+  },
+  handler: async (ctx, { stripeCustomerId, status, plan }) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_stripe_customer", (q) => q.eq("stripeCustomerId", stripeCustomerId))
+      .first();
+    if (!user) return;
+    await ctx.db.patch(user._id, {
+      planStatus: status,
+      plan: plan ?? undefined,
+      planUpdatedAt: Date.now()
+    });
+  }
+});

--- a/apps/convex/convex/users.ts
+++ b/apps/convex/convex/users.ts
@@ -1,0 +1,16 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { requireUser, requireUserDoc } from "./_lib/withUser";
+
+export const me = query({
+  args: {},
+  handler: async (ctx) => requireUserDoc(ctx)
+});
+
+export const updateProfile = mutation({
+  args: { name: v.string() },
+  handler: async (ctx, { name }) => {
+    const userId = await requireUser(ctx);
+    await ctx.db.patch(userId, { name });
+  }
+});

--- a/apps/convex/package.json
+++ b/apps/convex/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "convex dev",
     "deploy": "convex deploy",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@acme/config": "workspace:*",
@@ -14,6 +15,7 @@
     "convex": "1.31.6"
   },
   "devDependencies": {
+    "convex-test": "0.0.41",
     "typescript": "5.9.3"
   }
 }

--- a/apps/convex/package.json
+++ b/apps/convex/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@acme/config": "workspace:*",
     "convex": "1.31.6"
   },
   "devDependencies": {

--- a/apps/convex/package.json
+++ b/apps/convex/package.json
@@ -12,7 +12,8 @@
     "@acme/config": "workspace:*",
     "@auth/core": "0.37.4",
     "@convex-dev/auth": "0.0.92",
-    "convex": "1.31.6"
+    "convex": "1.31.6",
+    "stripe": "22.1.1"
   },
   "devDependencies": {
     "convex-test": "0.0.41",

--- a/apps/convex/package.json
+++ b/apps/convex/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@acme/config": "workspace:*",
-    "@auth/core": "0.34.3",
+    "@auth/core": "0.37.4",
     "@convex-dev/auth": "0.0.92",
     "convex": "1.31.6"
   },

--- a/apps/convex/package.json
+++ b/apps/convex/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "@acme/config": "workspace:*",
+    "@auth/core": "0.34.3",
+    "@convex-dev/auth": "0.0.92",
     "convex": "1.31.6"
   },
   "devDependencies": {

--- a/apps/convex/tsconfig.json
+++ b/apps/convex/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@acme/config": ["../../packages/config/src/index.ts"],
+      "@acme/config/schema": ["../../packages/config/src/schema.ts"]
+    }
+  },
   "include": [
     "convex",
     "**/*.ts",

--- a/apps/convex/tsconfig.json
+++ b/apps/convex/tsconfig.json
@@ -10,5 +10,8 @@
     "convex",
     "**/*.ts",
     "**/*.tsx"
+  ],
+  "exclude": [
+    "convex/**/*.test.ts"
   ]
 }

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,0 +1,3 @@
+# Public envs only — these are inlined into the client bundle.
+NEXT_PUBLIC_CONVEX_URL=
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { headers } from "next/headers";
 import "@/styles/globals.css";
 
 export const metadata: Metadata = {
@@ -7,7 +8,10 @@ export const metadata: Metadata = {
   description: "A production-ready monorepo for building AI-powered applications"
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  // Nonce wired via middleware.ts; forks rendering <Script> tags pass this prop.
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+  void nonce;
   return (
     <html lang="en">
       <body>{children}</body>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import { headers } from "next/headers";
 import "@/styles/globals.css";
 
 export const metadata: Metadata = {
@@ -8,10 +7,10 @@ export const metadata: Metadata = {
   description: "A production-ready monorepo for building AI-powered applications"
 };
 
-export default async function RootLayout({ children }: { children: ReactNode }) {
-  // Nonce wired via middleware.ts; forks rendering <Script> tags pass this prop.
-  const nonce = (await headers()).get("x-nonce") ?? undefined;
-  void nonce;
+// Nonce is wired through `x-nonce` by middleware.ts. Forks that render
+// `<Script>` tags should call `headers()` here and pass `nonce` to those tags,
+// which will switch this layout to dynamic rendering at that point.
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>{children}</body>

--- a/apps/web/middleware.test.ts
+++ b/apps/web/middleware.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, describe, beforeEach } from "bun:test";
+import { NextRequest } from "next/server";
+import { middleware } from "./middleware";
+
+function makeReq(path = "/"): NextRequest {
+  return new NextRequest(new URL(path, "http://localhost:3000"));
+}
+
+describe("middleware CSP", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "development";
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+  });
+
+  test("sets a nonce on the request and CSP on the response", async () => {
+    const res = await middleware(makeReq("/"));
+    const csp = res.headers.get("content-security-policy");
+    expect(csp).toBeTruthy();
+    const nonceMatch = csp!.match(/'nonce-([A-Za-z0-9+/=]+)'/);
+    expect(nonceMatch).not.toBeNull();
+    const nonce = nonceMatch![1];
+    expect(csp).toContain(`script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`);
+    expect(csp).toContain(`style-src 'self' 'nonce-${nonce}'`);
+  });
+
+  test("development CSP includes 'unsafe-eval' and ws://localhost", async () => {
+    process.env.NODE_ENV = "development";
+    const res = await middleware(makeReq("/"));
+    const csp = res.headers.get("content-security-policy")!;
+    expect(csp).toContain("'unsafe-eval'");
+    expect(csp).toContain("ws://localhost:*");
+  });
+
+  test("production CSP omits 'unsafe-eval'", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.STRIPE_SECRET_KEY = "sk_test_x";
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_x";
+    process.env.CONVEX_DEPLOYMENT = "prod:abc";
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    process.env.API_BEARER_TOKEN = "a".repeat(32);
+    const res = await middleware(makeReq("/"));
+    const csp = res.headers.get("content-security-policy")!;
+    expect(csp).not.toContain("'unsafe-eval'");
+  });
+
+  test("CSP includes the Convex URL in connect-src", async () => {
+    const res = await middleware(makeReq("/"));
+    const csp = res.headers.get("content-security-policy")!;
+    expect(csp).toContain("https://example.convex.cloud");
+    expect(csp).toContain("wss://example.convex.cloud");
+  });
+});

--- a/apps/web/middleware.test.ts
+++ b/apps/web/middleware.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, beforeEach } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { NextRequest } from "next/server";
 import { middleware } from "./middleware";
 
@@ -7,9 +7,18 @@ function makeReq(path = "/"): NextRequest {
 }
 
 describe("middleware CSP", () => {
+  const originalEnv = { ...process.env };
+
   beforeEach(() => {
     process.env.NODE_ENV = "development";
     process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
   });
 
   test("sets a nonce on the request and CSP on the response", async () => {
@@ -33,11 +42,6 @@ describe("middleware CSP", () => {
 
   test("production CSP omits 'unsafe-eval'", async () => {
     process.env.NODE_ENV = "production";
-    process.env.STRIPE_SECRET_KEY = "sk_test_x";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_x";
-    process.env.CONVEX_DEPLOYMENT = "prod:abc";
-    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
-    process.env.API_BEARER_TOKEN = "a".repeat(32);
     const res = await middleware(makeReq("/"));
     const csp = res.headers.get("content-security-policy")!;
     expect(csp).not.toContain("'unsafe-eval'");

--- a/apps/web/middleware.test.ts
+++ b/apps/web/middleware.test.ts
@@ -32,19 +32,21 @@ describe("middleware CSP", () => {
     expect(csp).toContain(`style-src 'self' 'nonce-${nonce}'`);
   });
 
-  test("development CSP includes 'unsafe-eval' and ws://localhost", async () => {
+  test("development CSP includes 'unsafe-eval' and ws://localhost; omits upgrade-insecure-requests", async () => {
     process.env.NODE_ENV = "development";
     const res = await middleware(makeReq("/"));
     const csp = res.headers.get("content-security-policy")!;
     expect(csp).toContain("'unsafe-eval'");
     expect(csp).toContain("ws://localhost:*");
+    expect(csp).not.toContain("upgrade-insecure-requests");
   });
 
-  test("production CSP omits 'unsafe-eval'", async () => {
+  test("production CSP omits 'unsafe-eval' and includes upgrade-insecure-requests", async () => {
     process.env.NODE_ENV = "production";
     const res = await middleware(makeReq("/"));
     const csp = res.headers.get("content-security-policy")!;
     expect(csp).not.toContain("'unsafe-eval'");
+    expect(csp).toContain("upgrade-insecure-requests");
   });
 
   test("CSP includes the Convex URL in connect-src", async () => {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,5 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { envSchema } from "@acme/config/schema";
+import { z } from "zod";
+
+const middlewareEnv = z.object({
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  NEXT_PUBLIC_CONVEX_URL: z.string().url().optional()
+});
 
 function makeNonce(): string {
   const bytes = new Uint8Array(16);
@@ -16,7 +21,7 @@ function convexWss(url: string | undefined): string {
 export function middleware(req: NextRequest) {
   // Parse env per-request — Edge runtime is fast, this keeps test mocking simple.
   // Production schema enforcement happens at app boot via @acme/config (Node).
-  const env = envSchema.parse({ ...process.env });
+  const env = middlewareEnv.parse(process.env);
   const nonce = makeNonce();
   const isProd = env.NODE_ENV === "production";
   const convexHttp = env.NEXT_PUBLIC_CONVEX_URL ?? "";

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,71 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { envSchema } from "@acme/config/schema";
+
+function makeNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  // base64 without padding
+  return btoa(String.fromCharCode(...bytes)).replace(/=+$/, "");
+}
+
+function convexWss(url: string | undefined): string {
+  if (!url) return "";
+  return url.replace(/^https:/, "wss:").replace(/^http:/, "ws:");
+}
+
+export function middleware(req: NextRequest) {
+  // Parse env per-request — Edge runtime is fast, this keeps test mocking simple.
+  // Production schema enforcement happens at app boot via @acme/config (Node).
+  const env = envSchema.parse({ ...process.env });
+  const nonce = makeNonce();
+  const isProd = env.NODE_ENV === "production";
+  const convexHttp = env.NEXT_PUBLIC_CONVEX_URL ?? "";
+  const convexWs = convexWss(convexHttp);
+
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    !isProd && "'unsafe-eval'"
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const connectSrc = [
+    "'self'",
+    convexHttp,
+    convexWs,
+    !isProd && "ws://localhost:*",
+    !isProd && "http://localhost:*"
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  // TODO(fork): add Stripe (https://js.stripe.com, https://api.stripe.com)
+  // and analytics origins to script-src / connect-src as needed.
+  const csp = [
+    `default-src 'self'`,
+    `script-src ${scriptSrc}`,
+    `style-src 'self' 'nonce-${nonce}'`,
+    `img-src 'self' blob: data:`,
+    `font-src 'self' data:`,
+    `connect-src ${connectSrc}`,
+    `frame-src 'none'`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `frame-ancestors 'none'`,
+    `upgrade-insecure-requests`
+  ].join("; ");
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-nonce", nonce);
+
+  const res = NextResponse.next({ request: { headers: requestHeaders } });
+  res.headers.set("content-security-policy", csp);
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)"]
+};

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -60,8 +60,12 @@ export function middleware(req: NextRequest) {
     `base-uri 'self'`,
     `form-action 'self'`,
     `frame-ancestors 'none'`,
-    `upgrade-insecure-requests`
-  ].join("; ");
+    // Only emit in production; otherwise the browser would upgrade allowed
+    // http://localhost and ws://localhost endpoints and break local Convex/API.
+    isProd && `upgrade-insecure-requests`
+  ]
+    .filter(Boolean)
+    .join("; ");
 
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-nonce", nonce);

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,1 +1,0 @@
-export default {};

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,0 +1,29 @@
+import type { NextConfig } from "next";
+
+const isProd = process.env.NODE_ENV === "production";
+
+const securityHeaders = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+  },
+  ...(isProd
+    ? [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload"
+        }
+      ]
+    : [])
+];
+
+const config: NextConfig = {
+  async headers() {
+    return [{ source: "/(.*)", headers: securityHeaders }];
+  }
+};
+
+export default config;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@acme/config": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,8 @@
     "next": "16.1.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "tailwind-merge": "^2.5.4"
+    "tailwind-merge": "^2.5.4",
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@acme/config": "workspace:*",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -43,6 +43,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/*.test.ts"
   ]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -27,6 +27,12 @@
       ],
       "@acme/ai": [
         "../../packages/ai/src/index.ts"
+      ],
+      "@acme/config": [
+        "../../packages/config/src/index.ts"
+      ],
+      "@acme/config/schema": [
+        "../../packages/config/src/schema.ts"
       ]
     }
   },

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,6 +7,9 @@
     "eval": "bun src/eval.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
+  "dependencies": {
+    "@acme/config": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "5.9.3"
   }

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@acme/config": ["../../packages/config/src/index.ts"],
+      "@acme/config/schema": ["../../packages/config/src/schema.ts"]
+    }
+  },
   "include": [
     "src"
   ]

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
     "apps/api": {
       "name": "api",
       "dependencies": {
+        "@acme/config": "workspace:*",
         "elysia": "1.4.22",
       },
       "devDependencies": {
@@ -26,6 +27,7 @@
     "apps/convex": {
       "name": "convex",
       "dependencies": {
+        "@acme/config": "workspace:*",
         "convex": "1.31.6",
       },
       "devDependencies": {
@@ -35,6 +37,7 @@
     "apps/web": {
       "name": "web",
       "dependencies": {
+        "@acme/config": "workspace:*",
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -58,6 +61,9 @@
     },
     "apps/worker": {
       "name": "worker",
+      "dependencies": {
+        "@acme/config": "workspace:*",
+      },
       "devDependencies": {
         "typescript": "5.9.3",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "convex": "1.31.6",
       },
       "devDependencies": {
+        "convex-test": "0.0.41",
         "typescript": "5.9.3",
       },
     },
@@ -550,6 +551,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convex": ["convex@workspace:apps/convex"],
+
+    "convex-test": ["convex-test@0.0.41", "", { "peerDependencies": { "convex": "^1.16.4" } }, "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@auth/core": "0.37.4",
         "@convex-dev/auth": "0.0.92",
         "convex": "1.31.6",
+        "stripe": "22.1.1",
       },
       "devDependencies": {
         "convex-test": "0.0.41",
@@ -1017,6 +1018,8 @@
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "stripe": ["stripe@22.1.1", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA=="],
 
     "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,8 @@
       "name": "convex",
       "dependencies": {
         "@acme/config": "workspace:*",
+        "@auth/core": "^0.34.3",
+        "@convex-dev/auth": "^0.0.92",
         "convex": "1.31.6",
       },
       "devDependencies": {
@@ -127,6 +129,8 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@auth/core": ["@auth/core@0.34.3", "", { "dependencies": { "@panva/hkdf": "^1.1.1", "@types/cookie": "0.6.0", "cookie": "0.6.0", "jose": "^5.1.3", "oauth4webapi": "^2.10.4", "preact": "10.11.3", "preact-render-to-string": "5.2.3" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^7" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.28.6", "", {}, "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg=="],
@@ -160,6 +164,8 @@
     "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+
+    "@convex-dev/auth": ["@convex-dev/auth@0.0.92", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0", "cookie": "^1.0.1", "is-network-error": "^1.1.0", "jose": "^5.2.2", "jwt-decode": "^4.0.0", "lucia": "^3.2.0", "oauth4webapi": "^3.1.2", "path-to-regexp": "^6.3.0", "server-only": "^0.0.1" }, "peerDependencies": { "@auth/core": "^0.37.0", "convex": "^1.17.0", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["react"], "bin": { "auth": "dist/bin.cjs" } }, "sha512-tNRIMTDxi2vrbT+3vz1FgNR1321IfIBDDBy59zul7E1DyzWQKoU0OzgFqWbiVm3o8gn0eQsYTU3UHNRX9kp3wQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -335,6 +341,16 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
+    "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
+
+    "@oslojs/binary": ["@oslojs/binary@1.0.0", "", {}, "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ=="],
+
+    "@oslojs/crypto": ["@oslojs/crypto@1.0.1", "", { "dependencies": { "@oslojs/asn1": "1.0.0", "@oslojs/binary": "1.0.0" } }, "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ=="],
+
+    "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
+
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
@@ -382,6 +398,8 @@
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/bun": ["@types/bun@1.2.5", "", { "dependencies": { "bun-types": "1.2.5" } }, "sha512-w2OZTzrZTVtbnJew1pdFmgV99H0/L+Pvw+z1P67HaR18MHOzYnTYOi6qzErhK8HyT+DB782ADVPPE92Xu2/Opg=="],
+
+    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -743,6 +761,8 @@
 
     "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
 
+    "is-network-error": ["is-network-error@1.3.2", "", {}, "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
@@ -773,6 +793,8 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -788,6 +810,8 @@
     "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -829,6 +853,8 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lucia": ["lucia@3.2.2", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0" } }, "sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA=="],
+
     "lucide-react": ["lucide-react@0.469.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -856,6 +882,8 @@
     "next": ["next@16.1.6", "", { "dependencies": { "@next/env": "16.1.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.6", "@next/swc-darwin-x64": "16.1.6", "@next/swc-linux-arm64-gnu": "16.1.6", "@next/swc-linux-arm64-musl": "16.1.6", "@next/swc-linux-x64-gnu": "16.1.6", "@next/swc-linux-x64-musl": "16.1.6", "@next/swc-win32-arm64-msvc": "16.1.6", "@next/swc-win32-x64-msvc": "16.1.6", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+
+    "oauth4webapi": ["oauth4webapi@2.17.0", "", {}, "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -891,6 +919,8 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -899,9 +929,15 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "preact": ["preact@10.11.3", "", {}, "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@5.2.3", "", { "dependencies": { "pretty-format": "^3.8.0" }, "peerDependencies": { "preact": ">=10" } }, "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "pretty-format": ["pretty-format@3.8.0", "", {}, "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
@@ -938,6 +974,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -1073,7 +1111,11 @@
 
     "@acme/schemas/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@auth/core/cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "@convex-dev/auth/oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "ai-swiss-army-template",
+      "dependencies": {
+        "zod": "3.23.8",
+      },
       "devDependencies": {
         "@types/node": "^25.0.10",
         "@types/react": "^19.2.10",
@@ -54,6 +57,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "tailwind-merge": "^2.5.4",
+        "zod": "3.23.8",
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
@@ -1220,8 +1224,6 @@
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
-
-    "zod-validation-error/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -28,8 +28,8 @@
       "name": "convex",
       "dependencies": {
         "@acme/config": "workspace:*",
-        "@auth/core": "^0.34.3",
-        "@convex-dev/auth": "^0.0.92",
+        "@auth/core": "0.37.4",
+        "@convex-dev/auth": "0.0.92",
         "convex": "1.31.6",
       },
       "devDependencies": {
@@ -129,7 +129,7 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@auth/core": ["@auth/core@0.34.3", "", { "dependencies": { "@panva/hkdf": "^1.1.1", "@types/cookie": "0.6.0", "cookie": "0.6.0", "jose": "^5.1.3", "oauth4webapi": "^2.10.4", "preact": "10.11.3", "preact-render-to-string": "5.2.3" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^7" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw=="],
+    "@auth/core": ["@auth/core@0.37.4", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^5.9.6", "oauth4webapi": "^3.1.1", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^6.8.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 
@@ -398,8 +398,6 @@
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/bun": ["@types/bun@1.2.5", "", { "dependencies": { "bun-types": "1.2.5" } }, "sha512-w2OZTzrZTVtbnJew1pdFmgV99H0/L+Pvw+z1P67HaR18MHOzYnTYOi6qzErhK8HyT+DB782ADVPPE92Xu2/Opg=="],
-
-    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -883,7 +881,7 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
-    "oauth4webapi": ["oauth4webapi@2.17.0", "", {}, "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ=="],
+    "oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -929,15 +927,13 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
-    "preact": ["preact@10.11.3", "", {}, "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="],
+    "preact": ["preact@10.24.3", "", {}, "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="],
 
-    "preact-render-to-string": ["preact-render-to-string@5.2.3", "", { "dependencies": { "pretty-format": "^3.8.0" }, "peerDependencies": { "preact": ">=10" } }, "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA=="],
+    "preact-render-to-string": ["preact-render-to-string@6.5.11", "", { "peerDependencies": { "preact": ">=10" } }, "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
-
-    "pretty-format": ["pretty-format@3.8.0", "", {}, "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
@@ -1111,11 +1107,7 @@
 
     "@acme/schemas/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@auth/core/cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
-
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
-
-    "@convex-dev/auth/oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,10 +17,14 @@
       "name": "api",
       "dependencies": {
         "@acme/config": "workspace:*",
+        "@elysiajs/bearer": "1.4.4",
+        "@elysiajs/cors": "1.4.2",
         "elysia": "1.4.22",
+        "pino": "10.3.1",
       },
       "devDependencies": {
         "@types/bun": "1.2.5",
+        "pino-pretty": "13.1.3",
         "typescript": "^5.5.0",
       },
     },
@@ -168,6 +172,10 @@
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 
     "@convex-dev/auth": ["@convex-dev/auth@0.0.92", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0", "cookie": "^1.0.1", "is-network-error": "^1.1.0", "jose": "^5.2.2", "jwt-decode": "^4.0.0", "lucia": "^3.2.0", "oauth4webapi": "^3.1.2", "path-to-regexp": "^6.3.0", "server-only": "^0.0.1" }, "peerDependencies": { "@auth/core": "^0.37.0", "convex": "^1.17.0", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["react"], "bin": { "auth": "dist/bin.cjs" } }, "sha512-tNRIMTDxi2vrbT+3vz1FgNR1321IfIBDDBy59zul7E1DyzWQKoU0OzgFqWbiVm3o8gn0eQsYTU3UHNRX9kp3wQ=="],
+
+    "@elysiajs/bearer": ["@elysiajs/bearer@1.4.4", "", { "peerDependencies": { "elysia": ">= 1.4.3" } }, "sha512-NCMiTEwLmqfxkbaTHYvZXvmO+CHmHVNlLLNa+0RcJviK88abVeSnn6wswgABGGTRJJTkfw3Ks3fw/7um3bxeRQ=="],
+
+    "@elysiajs/cors": ["@elysiajs/cors@1.4.2", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-FTCcbH35brTLigF1W7BYySRZomgI/dBEMK9BgK9RP9Nez7zmpGh4koL/Yr1BFv8nYz7CfhRvcM8d/c+XnwMaVQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -353,6 +361,8 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
@@ -507,6 +517,8 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
@@ -547,6 +559,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
@@ -569,6 +583,8 @@
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
@@ -590,6 +606,8 @@
     "elysia": ["elysia@1.4.22", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.6", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Q90VCb1RVFxnFaRV0FDoSylESQQLWgLHFmWciQJdX9h3b2cSasji9KWEUvaJuy/L9ciAGg4RAhUVfsXHg5K2RQ=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
 
@@ -649,6 +667,8 @@
 
     "exact-mirror": ["exact-mirror@0.2.6", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-7s059UIx9/tnOKSySzUk5cPGkoILhTE4p6ncf6uIPaQ+9aRBQzQjc9+q85l51+oZ+P6aBxh084pD0CzBQPcFUA=="],
 
+    "fast-copy": ["fast-copy@4.0.3", "", {}, "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw=="],
+
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -658,6 +678,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -718,6 +740,8 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
@@ -796,6 +820,8 @@
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -903,6 +929,10 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -927,6 +957,14 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -939,17 +977,25 @@
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -971,7 +1017,11 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -997,7 +1047,11 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
@@ -1017,7 +1071,7 @@
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
-    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "stripe": ["stripe@22.1.1", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA=="],
 
@@ -1034,6 +1088,8 @@
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "thread-stream": ["thread-stream@4.1.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
@@ -1103,6 +1159,8 @@
 
     "worker": ["worker@workspace:apps/worker"],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
@@ -1116,6 +1174,8 @@
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -1158,6 +1218,8 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "zod-validation-error/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,10 @@
     },
     "packages/config": {
       "name": "@acme/config",
+      "dependencies": {
+        "dotenv": "16.4.7",
+        "zod": "3.23.8",
+      },
       "devDependencies": {
         "typescript": "5.9.3",
       },
@@ -550,6 +554,8 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1055,9 +1061,11 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "@acme/schemas/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -1093,6 +1101,8 @@
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
+    "eslint-plugin-react-hooks/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "is-bun-module/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
@@ -1102,6 +1112,8 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "zod-validation-error/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
   }

--- a/docs/superpowers/plans/2026-05-12-foundation-hardening.md
+++ b/docs/superpowers/plans/2026-05-12-foundation-hardening.md
@@ -1000,7 +1000,9 @@ http.route({
     const stripe = getStripe();
     let event: Stripe.Event;
     try {
-      event = stripe.webhooks.constructEvent(
+      // Convex's runtime is Web-Crypto only — `constructEvent` fails with
+      // "SubtleCryptoProvider cannot be used in a synchronous context."
+      event = await stripe.webhooks.constructEventAsync(
         body,
         sig,
         env.STRIPE_WEBHOOK_SECRET,

--- a/docs/superpowers/plans/2026-05-12-foundation-hardening.md
+++ b/docs/superpowers/plans/2026-05-12-foundation-hardening.md
@@ -1,0 +1,1781 @@
+# Foundation Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** make the template's defaults safe to fork — add env validation, Stripe webhook signature verification, Convex Auth, CSP/security headers, and a hardened Elysia skeleton, all backed by tests.
+
+**Architecture:** one Zod env schema in `packages/config` parsed twice (Node loader for Next/Elysia/Worker, Convex-side loader inside `apps/convex`). Stripe webhook verifies the raw body, records the event ID for idempotency, applies subscription state to the `users` table. Convex Auth's `Password` provider wires `@convex-dev/auth` and re-exports a `requireUser` guard. Next.js gets a CSP-nonce middleware plus static headers in `next.config.ts`. Elysia composes CORS + security-headers + bearer guard + in-memory rate limit on `/protected/*` with structured pino logging and graceful shutdown.
+
+**Tech Stack:** Bun 1.3.7 (test runner), Turborepo 2.7.6, Convex 1.31.6, `@convex-dev/auth`, Stripe SDK, Next.js 16.1.6 (Edge middleware), Elysia 1.4.22, Zod 3.x, pino. Workspace scope is `@acme/*` (rename to `@cas/*` is Sub-project 6, out of scope here).
+
+**Reference spec:** `docs/superpowers/specs/2026-05-12-foundation-hardening-design.md`.
+
+---
+
+## Pre-flight conventions
+
+- **Package versions:** when a new dep is added, install with `bun add <name>@<latest-stable>` (exact pin, no `^`). After each install, add the name to the right block in `tooling/scripts/check-versions.ts` with the version you just installed. `bun run check:versions` must pass after every commit.
+- **Bun test:** all tests use `import { test, expect, describe } from "bun:test"` and run via `bun test` from the workspace root or the package dir.
+- **Commits:** small, focused, one per task. Use Conventional Commits (`feat:`, `fix:`, `chore:`, `test:`, `docs:`). No mention of Claude/AI.
+- **Worktree:** this plan executes inside an existing worktree (`worktree-foundation-hardening-spec`). Do not switch branches.
+
+---
+
+## Task 1: Add zod + dotenv to `packages/config`
+
+**Files:**
+- Modify: `packages/config/package.json`
+- Modify: `tooling/scripts/check-versions.ts`
+
+- [ ] **Step 1: Install zod and dotenv into the config package**
+
+Run:
+```bash
+bun add --filter=@acme/config zod@3.23.8 dotenv@16.4.7
+```
+
+Expected: both deps appear under `packages/config/package.json` `dependencies` with exact pins.
+
+- [ ] **Step 2: Verify pins are exact**
+
+Run: `grep -E '"(zod|dotenv)"' packages/config/package.json`
+Expected output contains `"zod": "3.23.8"` and `"dotenv": "16.4.7"` (no `^`/`~`).
+
+- [ ] **Step 3: Extend `tooling/scripts/check-versions.ts` to enforce the new pins**
+
+Open `tooling/scripts/check-versions.ts`. Locate the `PINS` constant. Add a `config` section (the existing `PINS.root` and `PINS.web` show the shape):
+
+```ts
+// Inside the PINS object, alongside `root` and `web`:
+  config: {
+    dependencies: {
+      zod: "3.23.8",
+      dotenv: "16.4.7"
+    }
+  },
+```
+
+Then find the section at the bottom of the file that calls `assertEq` per workspace. Add:
+
+```ts
+// --- @acme/config ---
+const cfgPkg = readJSON(join(process.cwd(), "packages/config/package.json"));
+assertEq("config.zod", getDep(cfgPkg, "zod"), PINS.config.dependencies.zod);
+assertEq("config.dotenv", getDep(cfgPkg, "dotenv"), PINS.config.dependencies.dotenv);
+```
+
+(Pattern-match the file's existing style — copy the closest existing block and adapt.)
+
+- [ ] **Step 4: Verify the version check passes**
+
+Run: `bun tooling/scripts/check-versions.ts`
+Expected: exits 0 with no error output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/config/package.json package.json bun.lock tooling/scripts/check-versions.ts
+git commit -m "chore(config): pin zod and dotenv in @acme/config"
+```
+
+---
+
+## Task 2: Write the env schema test (failing)
+
+**Files:**
+- Create: `packages/config/src/schema.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/config/src/schema.test.ts`:
+
+```ts
+import { test, expect, describe } from "bun:test";
+import { parseEnv } from "./schema";
+
+const validProd = {
+  NODE_ENV: "production",
+  STRIPE_SECRET_KEY: "sk_test_x",
+  STRIPE_WEBHOOK_SECRET: "whsec_x",
+  CONVEX_DEPLOYMENT: "dev:abc",
+  NEXT_PUBLIC_CONVEX_URL: "https://example.convex.cloud",
+  NEXT_PUBLIC_APP_URL: "https://app.example.com",
+  API_BEARER_TOKEN: "a".repeat(32)
+};
+
+describe("parseEnv", () => {
+  test("parses a valid dev env and applies defaults", () => {
+    const env = parseEnv({ NODE_ENV: "development" }, "development");
+    expect(env.NODE_ENV).toBe("development");
+    expect(env.WEBHOOK_TOLERANCE_SECONDS).toBe(300);
+    expect(env.API_PORT).toBe(3001);
+    expect(env.LOG_LEVEL).toBe("info");
+  });
+
+  test("parses a valid production env with all required fields", () => {
+    const env = parseEnv(validProd, "production");
+    expect(env.STRIPE_SECRET_KEY).toBe("sk_test_x");
+    expect(env.API_BEARER_TOKEN.length).toBe(32);
+  });
+
+  test("rejects production env missing STRIPE_SECRET_KEY", () => {
+    const { STRIPE_SECRET_KEY: _, ...partial } = validProd;
+    expect(() => parseEnv(partial, "production")).toThrow(/STRIPE_SECRET_KEY/);
+  });
+
+  test("rejects production env with too-short API_BEARER_TOKEN", () => {
+    expect(() =>
+      parseEnv({ ...validProd, API_BEARER_TOKEN: "short" }, "production")
+    ).toThrow(/API_BEARER_TOKEN/);
+  });
+
+  test("rejects invalid NODE_ENV value", () => {
+    expect(() => parseEnv({ NODE_ENV: "staging" }, "staging")).toThrow(/NODE_ENV/);
+  });
+
+  test("coerces numeric string envs", () => {
+    const env = parseEnv(
+      { NODE_ENV: "development", API_PORT: "4000", WEBHOOK_TOLERANCE_SECONDS: "60" },
+      "development"
+    );
+    expect(env.API_PORT).toBe(4000);
+    expect(env.WEBHOOK_TOLERANCE_SECONDS).toBe(60);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/config && bun test`
+Expected: FAIL — `Cannot find module './schema'` (or similar). The test file references a `schema.ts` we have not written yet.
+
+---
+
+## Task 3: Implement `packages/config/src/schema.ts`
+
+**Files:**
+- Create: `packages/config/src/schema.ts`
+
+- [ ] **Step 1: Write the schema module**
+
+Create `packages/config/src/schema.ts`:
+
+```ts
+import { z } from "zod";
+
+export type Mode = "development" | "test" | "production";
+
+const optionalUrl = z.string().url().optional();
+const optionalStr = z.string().optional();
+
+export const envSchema = z
+  .object({
+    NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+
+    STRIPE_SECRET_KEY: optionalStr,
+    STRIPE_WEBHOOK_SECRET: optionalStr,
+    CONVEX_DEPLOYMENT: optionalStr,
+    NEXT_PUBLIC_CONVEX_URL: optionalUrl,
+    NEXT_PUBLIC_APP_URL: optionalUrl,
+    API_BEARER_TOKEN: z.string().min(32).optional(),
+
+    WEBHOOK_TOLERANCE_SECONDS: z.coerce.number().int().positive().default(300),
+    API_PORT: z.coerce.number().int().positive().default(3001),
+    LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info")
+  })
+  .superRefine((env, ctx) => {
+    if (env.NODE_ENV !== "production") return;
+    const requiredInProd: Array<keyof typeof env> = [
+      "STRIPE_SECRET_KEY",
+      "STRIPE_WEBHOOK_SECRET",
+      "CONVEX_DEPLOYMENT",
+      "NEXT_PUBLIC_CONVEX_URL",
+      "NEXT_PUBLIC_APP_URL",
+      "API_BEARER_TOKEN"
+    ];
+    for (const key of requiredInProd) {
+      if (!env[key]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `${key} is required when NODE_ENV=production`
+        });
+      }
+    }
+  });
+
+export type Env = z.infer<typeof envSchema>;
+
+export function parseEnv(input: Record<string, unknown>, mode: string): Env {
+  const candidate = { ...input, NODE_ENV: mode ?? input.NODE_ENV };
+  const result = envSchema.safeParse(candidate);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    throw new Error(`Invalid environment: ${detail}`);
+  }
+  return result.data;
+}
+```
+
+- [ ] **Step 2: Run the schema tests to verify they pass**
+
+Run: `cd packages/config && bun test`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd packages/config && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 4: Add a `test` script to `packages/config/package.json` so `turbo test` picks it up**
+
+In `packages/config/package.json`, change the `scripts` block to include:
+
+```json
+"scripts": {
+  "typecheck": "tsc -p tsconfig.json --noEmit",
+  "test": "bun test"
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/config/src/schema.ts packages/config/src/schema.test.ts packages/config/package.json
+git commit -m "feat(config): add Zod env schema with NODE_ENV-conditional required fields"
+```
+
+---
+
+## Task 4: Implement `packages/config/src/node.ts` (Node-runtime loader)
+
+**Files:**
+- Create: `packages/config/src/node.ts`
+- Modify: `packages/config/src/index.ts`
+
+- [ ] **Step 1: Write the Node loader**
+
+Create `packages/config/src/node.ts`:
+
+```ts
+import { parseEnv, type Env } from "./schema";
+
+if (process.env.NODE_ENV !== "production") {
+  // Best-effort .env loading in non-prod; ignore if dotenv is absent.
+  try {
+    const dotenv = await import("dotenv");
+    dotenv.config();
+  } catch {
+    // dotenv is an optional runtime convenience; production deploys inject env directly.
+  }
+}
+
+const mode = process.env.NODE_ENV ?? "development";
+export const env: Env = Object.freeze(parseEnv(process.env, mode));
+```
+
+- [ ] **Step 2: Replace the placeholder entrypoint**
+
+Open `packages/config/src/index.ts`. Replace the entire contents with:
+
+```ts
+export { env } from "./node";
+export type { Env, Mode } from "./schema";
+export { envSchema, parseEnv } from "./schema";
+```
+
+- [ ] **Step 3: Add an `exports` map to `packages/config/package.json`**
+
+So that `import from "@acme/config"` and `import from "@acme/config/schema"` resolve via Node-style module resolution (Convex's deploy-time bundler needs this; tsconfig path aliases alone are not enough for the Convex runtime).
+
+Add to `packages/config/package.json`:
+
+```json
+"exports": {
+  ".": "./src/index.ts",
+  "./schema": "./src/schema.ts"
+}
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd packages/config && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 5: Manual smoke check the loader**
+
+Run from the repo root:
+```bash
+NODE_ENV=development bun -e 'import("@acme/config").then(m => console.log(m.env.API_PORT))'
+```
+Expected: prints `3001`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/config/src/node.ts packages/config/src/index.ts packages/config/package.json
+git commit -m "feat(config): add Node loader and exports map"
+```
+
+---
+
+## Task 5: Wire `@acme/config` into workspace path aliases
+
+**Files:**
+- Modify: `apps/web/tsconfig.json`
+- Modify: `apps/api/tsconfig.json`
+- Modify: `apps/worker/tsconfig.json`
+- Modify: `apps/convex/tsconfig.json`
+
+- [ ] **Step 1: Add `@acme/config` and `@acme/config/schema` to `apps/web/tsconfig.json`**
+
+Open `apps/web/tsconfig.json`. The `paths` block currently has entries for `@acme/shared`, `@acme/schemas`, `@acme/prompts`, `@acme/ai`. Add at the end of `paths`:
+
+```json
+      "@acme/config": [
+        "../../packages/config/src/index.ts"
+      ],
+      "@acme/config/schema": [
+        "../../packages/config/src/schema.ts"
+      ]
+```
+
+(Mind the trailing comma on the previous entry.)
+
+- [ ] **Step 2: Add the same two entries to `apps/api/tsconfig.json`**
+
+Open `apps/api/tsconfig.json`. If it has no `paths` block, add one inside `compilerOptions`:
+
+```json
+"paths": {
+  "@acme/config": ["../../packages/config/src/index.ts"],
+  "@acme/config/schema": ["../../packages/config/src/schema.ts"]
+}
+```
+
+If it already has a `paths` block, just add the two entries.
+
+- [ ] **Step 3: Repeat for `apps/worker/tsconfig.json` and `apps/convex/tsconfig.json`**
+
+Same `paths` additions. The Convex tsconfig only resolves at typecheck time — Convex's bundler resolves `@acme/config/schema` via `node_modules`-style workspace links at deploy time, so step 4 below adds the workspace dep declarations.
+
+- [ ] **Step 4: Add `@acme/config` as a workspace dependency in every consuming app**
+
+For each of `apps/web/package.json`, `apps/api/package.json`, `apps/worker/package.json`, `apps/convex/package.json`, add to `dependencies`:
+
+```json
+"@acme/config": "workspace:*"
+```
+
+Then run from the repo root: `bun install`
+Expected: lockfile updates, no errors.
+
+- [ ] **Step 5: Verify typecheck across the repo**
+
+Run: `bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/*/tsconfig.json apps/*/package.json bun.lock
+git commit -m "chore: wire @acme/config into all app workspaces"
+```
+
+---
+
+## Task 6: Install Convex Auth + create Convex-side env loader
+
+**Files:**
+- Modify: `apps/convex/package.json`
+- Create: `apps/convex/convex/_lib/env.ts`
+- Modify: `tooling/scripts/check-versions.ts`
+
+- [ ] **Step 1: Install `@convex-dev/auth`**
+
+Run from the repo root:
+```bash
+bun add --filter=convex @convex-dev/auth@latest @auth/core@latest
+```
+
+(`@auth/core` is `@convex-dev/auth`'s peer dependency.)
+
+After install, note the resolved versions (look in `apps/convex/package.json`).
+
+- [ ] **Step 2: Convert the resolved versions to exact pins**
+
+Open `apps/convex/package.json`. If either dep has a `^` or `~`, replace with the exact resolved version (find it in `bun.lock` or `node_modules/<dep>/package.json`).
+
+- [ ] **Step 3: Add the two pins to `tooling/scripts/check-versions.ts`**
+
+In `PINS`, add a `convex` section (or extend an existing one):
+
+```ts
+  convex: {
+    dependencies: {
+      convex: "1.31.6",
+      "@convex-dev/auth": "<the version you just installed>",
+      "@auth/core": "<the version you just installed>"
+    }
+  },
+```
+
+And at the bottom of the file, add the corresponding `assertEq` calls for the convex workspace, mirroring the pattern used for `web`.
+
+- [ ] **Step 4: Verify pins**
+
+Run: `bun run check:versions`
+Expected: exits 0.
+
+- [ ] **Step 5: Create the Convex-side env loader**
+
+Create `apps/convex/convex/_lib/env.ts`:
+
+```ts
+import { parseEnv, type Env } from "@acme/config/schema";
+
+const mode = process.env.NODE_ENV ?? "development";
+export const env: Env = Object.freeze(parseEnv(process.env, mode));
+```
+
+- [ ] **Step 6: Typecheck convex**
+
+Run: `cd apps/convex && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/convex/package.json apps/convex/convex/_lib/env.ts tooling/scripts/check-versions.ts bun.lock
+git commit -m "feat(convex): install Convex Auth and add Convex-side env loader"
+```
+
+---
+
+## Task 7: Extend the Convex schema (users + auth tables + processedStripeEvents)
+
+**Files:**
+- Modify: `apps/convex/convex/schema.ts`
+
+- [ ] **Step 1: Replace `apps/convex/convex/schema.ts` with the expanded schema**
+
+Open `apps/convex/convex/schema.ts`. Replace contents with:
+
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+import { authTables } from "@convex-dev/auth/server";
+
+export default defineSchema({
+  ...authTables,
+
+  users: defineTable({
+    email: v.string(),
+    tokenIdentifier: v.optional(v.string()),
+    name: v.optional(v.string()),
+    image: v.optional(v.string()),
+
+    stripeCustomerId: v.optional(v.string()),
+    plan: v.optional(v.string()),
+    planStatus: v.optional(v.string()),
+    planUpdatedAt: v.optional(v.number()),
+
+    createdAt: v.number()
+  })
+    .index("by_email", ["email"])
+    .index("by_token", ["tokenIdentifier"])
+    .index("by_stripe_customer", ["stripeCustomerId"]),
+
+  processedStripeEvents: defineTable({
+    eventId: v.string(),
+    type: v.string(),
+    processedAt: v.number()
+  }).index("by_eventId", ["eventId"])
+});
+```
+
+- [ ] **Step 2: Typecheck convex**
+
+Run: `cd apps/convex && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 3: Dry-run a Convex deploy to confirm schema validity**
+
+Run: `cd apps/convex && bunx convex deploy --dry-run` (requires `CONVEX_DEPLOYMENT` set; if unset locally, skip this step and rely on typecheck).
+Expected: no schema errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/convex/convex/schema.ts
+git commit -m "feat(convex): expand users schema and add processedStripeEvents + auth tables"
+```
+
+---
+
+## Task 8: Wire Convex Auth (`auth.ts`, `auth.config.ts`)
+
+**Files:**
+- Create: `apps/convex/convex/auth.ts`
+- Create: `apps/convex/convex/auth.config.ts`
+
+- [ ] **Step 1: Create `apps/convex/convex/auth.config.ts`**
+
+```ts
+// SITE_URL is set via `bunx convex env set SITE_URL <url>` and lives in the
+// Convex dashboard, not in @acme/config (which never reaches Convex's runtime
+// for SITE_URL specifically — it's read here only).
+export default {
+  providers: [
+    {
+      domain: process.env.SITE_URL!,
+      applicationID: "convex"
+    }
+  ]
+};
+```
+
+- [ ] **Step 2: Create `apps/convex/convex/auth.ts`**
+
+```ts
+import { convexAuth } from "@convex-dev/auth/server";
+import { Password } from "@convex-dev/auth/providers/Password";
+
+/**
+ * Convex Auth wiring. The Password provider is the only built-in for the
+ * template; add GitHub/Google/etc. by following:
+ *   https://labs.convex.dev/auth/config/oauth
+ */
+export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
+  providers: [Password]
+});
+```
+
+- [ ] **Step 3: Typecheck convex**
+
+Run: `cd apps/convex && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/convex/convex/auth.ts apps/convex/convex/auth.config.ts
+git commit -m "feat(convex): wire @convex-dev/auth with Password provider"
+```
+
+---
+
+## Task 9: Write the `requireUser` test (failing)
+
+**Files:**
+- Create: `apps/convex/convex/_lib/withUser.test.ts`
+
+- [ ] **Step 1: Install `convex-test` as a dev dependency**
+
+Run: `bun add --filter=convex -d convex-test@latest`
+
+After install, replace the resolved version with an exact pin in `apps/convex/package.json` (no `^`). Add the pin to `tooling/scripts/check-versions.ts` under the convex devDependencies.
+
+Run: `bun run check:versions` to confirm.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/convex/convex/_lib/withUser.test.ts`:
+
+```ts
+import { test, expect, describe } from "bun:test";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+
+describe("requireUser", () => {
+  test("users.me throws when unauthenticated", async () => {
+    const t = convexTest(schema);
+    await expect(t.query(api.users.me, {})).rejects.toThrow(/UNAUTHENTICATED/);
+  });
+
+  test("users.me returns the user doc when authenticated", async () => {
+    const t = convexTest(schema);
+    const userId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        email: "alice@example.com",
+        tokenIdentifier: "convex:alice",
+        createdAt: Date.now()
+      });
+    });
+    const asAlice = t.withIdentity({ tokenIdentifier: "convex:alice", subject: userId });
+    const me = await asAlice.query(api.users.me, {});
+    expect(me?.email).toBe("alice@example.com");
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd apps/convex && bun test`
+Expected: FAIL — `api.users` is undefined (we have not created `users.ts` yet) and `requireUser` does not exist.
+
+---
+
+## Task 10: Implement `requireUser` + `users.me` / `updateProfile`
+
+**Files:**
+- Create: `apps/convex/convex/_lib/withUser.ts`
+- Create: `apps/convex/convex/users.ts`
+
+- [ ] **Step 1: Create the guard helper**
+
+Create `apps/convex/convex/_lib/withUser.ts`:
+
+```ts
+import { ConvexError } from "convex/values";
+import type { QueryCtx, MutationCtx } from "../_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+type Ctx = QueryCtx | MutationCtx;
+
+export async function requireUser(ctx: Ctx) {
+  const userId = await getAuthUserId(ctx);
+  if (!userId) throw new ConvexError({ code: "UNAUTHENTICATED" });
+  return userId;
+}
+
+export async function requireUserDoc(ctx: Ctx) {
+  const userId = await requireUser(ctx);
+  const user = await ctx.db.get(userId);
+  if (!user) throw new ConvexError({ code: "USER_NOT_FOUND" });
+  return user;
+}
+```
+
+- [ ] **Step 2: Create the example user queries**
+
+Create `apps/convex/convex/users.ts`:
+
+```ts
+import { query, mutation } from "./_generated/server";
+import { v } from "convex/values";
+import { requireUser, requireUserDoc } from "./_lib/withUser";
+
+export const me = query({
+  args: {},
+  handler: async (ctx) => requireUserDoc(ctx)
+});
+
+export const updateProfile = mutation({
+  args: { name: v.string() },
+  handler: async (ctx, { name }) => {
+    const userId = await requireUser(ctx);
+    await ctx.db.patch(userId, { name });
+  }
+});
+```
+
+- [ ] **Step 3: Regenerate Convex types**
+
+Run: `cd apps/convex && bunx convex codegen`
+Expected: `_generated/api.d.ts` updates to include `users.me` and `users.updateProfile`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/convex && bun test convex/_lib/withUser.test.ts`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Add `test` script to `apps/convex/package.json`**
+
+Add to `scripts`:
+
+```json
+"test": "bun test"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/convex/convex/_lib/withUser.ts apps/convex/convex/_lib/withUser.test.ts apps/convex/convex/users.ts apps/convex/convex/_generated apps/convex/package.json
+git commit -m "feat(convex): add requireUser guard and example users queries"
+```
+
+---
+
+## Task 11: Install Stripe SDK and create `_lib/stripe.ts`
+
+**Files:**
+- Modify: `apps/convex/package.json`
+- Create: `apps/convex/convex/_lib/stripe.ts`
+
+- [ ] **Step 1: Install Stripe SDK**
+
+Run: `bun add --filter=convex stripe@latest`
+
+Pin the exact version in `apps/convex/package.json` (no `^`). Add it to `tooling/scripts/check-versions.ts` under the convex deps.
+
+Run: `bun run check:versions` to confirm.
+
+- [ ] **Step 2: Create the lazy Stripe client**
+
+Create `apps/convex/convex/_lib/stripe.ts`:
+
+```ts
+import Stripe from "stripe";
+import { env } from "./env";
+
+// Pin apiVersion to the SDK's current default for the pinned stripe package.
+// When bumping the stripe dep, review the changelog and update this string.
+const API_VERSION = "2025-01-27.acacia" as const;
+
+let cached: Stripe | undefined;
+
+export function getStripe(): Stripe {
+  if (!cached) {
+    if (!env.STRIPE_SECRET_KEY) {
+      throw new Error("STRIPE_SECRET_KEY is required to use the Stripe client");
+    }
+    cached = new Stripe(env.STRIPE_SECRET_KEY, { apiVersion: API_VERSION });
+  }
+  return cached;
+}
+```
+
+> **Note for the implementer:** the `API_VERSION` string above is a placeholder for the version that ships with the resolved Stripe SDK. After installing, run `bun -e 'import("stripe").then(m => console.log(new m.default("sk_test_x").getApiField("version")))'` (or check `node_modules/stripe/types/lib.d.ts`) and replace `API_VERSION` with the actual default.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd apps/convex && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/convex/package.json apps/convex/convex/_lib/stripe.ts tooling/scripts/check-versions.ts bun.lock
+git commit -m "feat(convex): add Stripe SDK and lazy client"
+```
+
+---
+
+## Task 12: Write the Stripe webhook test (failing)
+
+**Files:**
+- Create: `apps/convex/convex/http.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/convex/convex/http.test.ts`:
+
+```ts
+import { test, expect, describe } from "bun:test";
+import { convexTest } from "convex-test";
+import Stripe from "stripe";
+import schema from "./schema";
+
+const SECRET = "whsec_test_secret_value";
+
+function signedRequest(body: string, secret: string): Request {
+  const stripe = new Stripe("sk_test_x", { apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion });
+  const header = stripe.webhooks.generateTestHeaderString({ payload: body, secret });
+  return new Request("https://convex.example/stripe/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": header, "content-type": "application/json" },
+    body
+  });
+}
+
+function unsignedRequest(body: string): Request {
+  return new Request("https://convex.example/stripe/webhook", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body
+  });
+}
+
+const baseEvent = (overrides: Partial<Record<string, unknown>> = {}) =>
+  JSON.stringify({
+    id: "evt_test_1",
+    type: "customer.subscription.updated",
+    data: {
+      object: {
+        customer: "cus_test_1",
+        status: "active",
+        items: { data: [{ price: { id: "price_x", lookup_key: "pro_monthly" } }] }
+      }
+    },
+    ...overrides
+  });
+
+describe("POST /stripe/webhook", () => {
+  test("returns 400 when Stripe-Signature is missing", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = SECRET;
+    process.env.STRIPE_SECRET_KEY = "sk_test_x";
+    const t = convexTest(schema);
+    const res = await t.fetch(unsignedRequest(baseEvent()));
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when the signature is invalid", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = SECRET;
+    process.env.STRIPE_SECRET_KEY = "sk_test_x";
+    const t = convexTest(schema);
+    const body = baseEvent();
+    const req = signedRequest(body, "whsec_wrong_secret");
+    const res = await t.fetch(req);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 200 on valid signature and updates the user plan", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = SECRET;
+    process.env.STRIPE_SECRET_KEY = "sk_test_x";
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        email: "alice@example.com",
+        stripeCustomerId: "cus_test_1",
+        createdAt: Date.now()
+      });
+    });
+    const res = await t.fetch(signedRequest(baseEvent(), SECRET));
+    expect(res.status).toBe(200);
+    const user = await t.run((ctx) =>
+      ctx.db.query("users").withIndex("by_stripe_customer", (q) => q.eq("stripeCustomerId", "cus_test_1")).first()
+    );
+    expect(user?.planStatus).toBe("active");
+    expect(user?.plan).toBe("pro_monthly");
+  });
+
+  test("replay of the same event id is idempotent", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = SECRET;
+    process.env.STRIPE_SECRET_KEY = "sk_test_x";
+    const t = convexTest(schema);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        email: "alice@example.com",
+        stripeCustomerId: "cus_test_1",
+        createdAt: Date.now()
+      })
+    );
+    const body = baseEvent();
+    await t.fetch(signedRequest(body, SECRET));
+    const res2 = await t.fetch(signedRequest(body, SECRET));
+    expect(res2.status).toBe(200);
+    const events = await t.run((ctx) => ctx.db.query("processedStripeEvents").collect());
+    expect(events.length).toBe(1);
+  });
+
+  test("customer.subscription.deleted sets planStatus to canceled", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = SECRET;
+    process.env.STRIPE_SECRET_KEY = "sk_test_x";
+    const t = convexTest(schema);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        email: "alice@example.com",
+        stripeCustomerId: "cus_test_1",
+        createdAt: Date.now()
+      })
+    );
+    const body = baseEvent({ id: "evt_test_2", type: "customer.subscription.deleted" });
+    const res = await t.fetch(signedRequest(body, SECRET));
+    expect(res.status).toBe(200);
+    const user = await t.run((ctx) =>
+      ctx.db.query("users").withIndex("by_stripe_customer", (q) => q.eq("stripeCustomerId", "cus_test_1")).first()
+    );
+    expect(user?.planStatus).toBe("canceled");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/convex && bun test convex/http.test.ts`
+Expected: FAIL — current `http.ts` returns 200 unconditionally; signature checks are not implemented; `internal.stripe` does not exist.
+
+---
+
+## Task 13: Implement the Stripe internal mutations
+
+**Files:**
+- Create: `apps/convex/convex/stripe.ts`
+
+- [ ] **Step 1: Create the internal mutations**
+
+Create `apps/convex/convex/stripe.ts`:
+
+```ts
+import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * Records a Stripe event ID. Returns true if newly recorded, false if duplicate
+ * (the caller should treat false as "already processed; skip work").
+ *
+ * Convex has no unique-index constraint. This is a read-then-insert; concurrent
+ * deliveries of the same event could race. Stripe retries are sequential in
+ * practice, so this is acceptable for a template. Forks needing strict
+ * uniqueness should layer their own pattern.
+ */
+export const recordEvent = internalMutation({
+  args: { eventId: v.string(), type: v.string() },
+  handler: async (ctx, { eventId, type }) => {
+    const existing = await ctx.db
+      .query("processedStripeEvents")
+      .withIndex("by_eventId", (q) => q.eq("eventId", eventId))
+      .first();
+    if (existing) return false;
+    await ctx.db.insert("processedStripeEvents", {
+      eventId,
+      type,
+      processedAt: Date.now()
+    });
+    return true;
+  }
+});
+
+export const applySubscriptionChange = internalMutation({
+  args: {
+    stripeCustomerId: v.string(),
+    status: v.string(),
+    plan: v.union(v.string(), v.null())
+  },
+  handler: async (ctx, { stripeCustomerId, status, plan }) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_stripe_customer", (q) => q.eq("stripeCustomerId", stripeCustomerId))
+      .first();
+    if (!user) return;
+    await ctx.db.patch(user._id, {
+      planStatus: status,
+      plan: plan ?? undefined,
+      planUpdatedAt: Date.now()
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Regenerate convex types**
+
+Run: `cd apps/convex && bunx convex codegen`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/convex/convex/stripe.ts apps/convex/convex/_generated
+git commit -m "feat(convex): add internal mutations for Stripe event idempotency and subscription sync"
+```
+
+---
+
+## Task 14: Implement the Stripe webhook handler
+
+**Files:**
+- Modify: `apps/convex/convex/http.ts`
+
+- [ ] **Step 1: Replace `apps/convex/convex/http.ts` contents**
+
+```ts
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { auth } from "./auth";
+import { getStripe } from "./_lib/stripe";
+import { env } from "./_lib/env";
+import type Stripe from "stripe";
+
+const http = httpRouter();
+
+// Mount Convex Auth routes (`/api/auth/*`).
+auth.addHttpRoutes(http);
+
+http.route({
+  path: "/stripe/webhook",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    if (!env.STRIPE_WEBHOOK_SECRET) {
+      return new Response("STRIPE_WEBHOOK_SECRET not configured", { status: 500 });
+    }
+
+    const body = await request.text();
+    const sig = request.headers.get("stripe-signature");
+    if (!sig) return new Response("missing signature", { status: 400 });
+
+    const stripe = getStripe();
+    let event: Stripe.Event;
+    try {
+      event = stripe.webhooks.constructEvent(
+        body,
+        sig,
+        env.STRIPE_WEBHOOK_SECRET,
+        env.WEBHOOK_TOLERANCE_SECONDS
+      );
+    } catch {
+      return new Response("invalid signature", { status: 400 });
+    }
+
+    const fresh = await ctx.runMutation(internal.stripe.recordEvent, {
+      eventId: event.id,
+      type: event.type
+    });
+    if (!fresh) return new Response(JSON.stringify({ received: true, duplicate: true }), { status: 200 });
+
+    switch (event.type) {
+      case "customer.subscription.created":
+      case "customer.subscription.updated": {
+        const sub = event.data.object as Stripe.Subscription;
+        const item = sub.items.data[0]?.price;
+        await ctx.runMutation(internal.stripe.applySubscriptionChange, {
+          stripeCustomerId: typeof sub.customer === "string" ? sub.customer : sub.customer.id,
+          status: sub.status,
+          plan: item?.lookup_key ?? item?.id ?? null
+        });
+        break;
+      }
+      case "customer.subscription.deleted": {
+        const sub = event.data.object as Stripe.Subscription;
+        await ctx.runMutation(internal.stripe.applySubscriptionChange, {
+          stripeCustomerId: typeof sub.customer === "string" ? sub.customer : sub.customer.id,
+          status: "canceled",
+          plan: null
+        });
+        break;
+      }
+      default:
+        console.info("unhandled stripe event type", event.type);
+    }
+
+    return new Response(JSON.stringify({ received: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  })
+});
+
+export default http;
+```
+
+- [ ] **Step 2: Run the webhook tests to verify they pass**
+
+Run: `cd apps/convex && bun test convex/http.test.ts`
+Expected: all 5 tests PASS.
+
+- [ ] **Step 3: Run the full convex test suite**
+
+Run: `cd apps/convex && bun test`
+Expected: all tests PASS (webhook + withUser).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/convex/convex/http.ts
+git commit -m "feat(convex): verify Stripe webhook signatures and sync subscription state"
+```
+
+---
+
+## Task 15: Write the Next.js middleware CSP test (failing)
+
+**Files:**
+- Create: `apps/web/middleware.test.ts`
+
+- [ ] **Step 1: Add `bun test` script to `apps/web/package.json`**
+
+Add to `scripts`:
+
+```json
+"test": "bun test"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web/middleware.test.ts`:
+
+```ts
+import { test, expect, describe, beforeEach } from "bun:test";
+import { NextRequest } from "next/server";
+import { middleware } from "./middleware";
+
+function makeReq(path = "/"): NextRequest {
+  return new NextRequest(new URL(path, "http://localhost:3000"));
+}
+
+describe("middleware CSP", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "development";
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+  });
+
+  test("sets a nonce on the request and CSP on the response", async () => {
+    const res = await middleware(makeReq("/"));
+    const csp = res.headers.get("content-security-policy");
+    expect(csp).toBeTruthy();
+    const nonceMatch = csp!.match(/'nonce-([A-Za-z0-9+/=]+)'/);
+    expect(nonceMatch).not.toBeNull();
+    const nonce = nonceMatch![1];
+    expect(csp).toContain(`script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`);
+    expect(csp).toContain(`style-src 'self' 'nonce-${nonce}'`);
+  });
+
+  test("development CSP includes 'unsafe-eval' and ws://localhost", async () => {
+    process.env.NODE_ENV = "development";
+    const res = await middleware(makeReq("/"));
+    const csp = res.headers.get("content-security-policy")!;
+    expect(csp).toContain("'unsafe-eval'");
+    expect(csp).toContain("ws://localhost:*");
+  });
+
+  test("production CSP omits 'unsafe-eval'", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.STRIPE_SECRET_KEY = "sk_test_x";
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_x";
+    process.env.CONVEX_DEPLOYMENT = "prod:abc";
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    process.env.API_BEARER_TOKEN = "a".repeat(32);
+    const res = await middleware(makeReq("/"));
+    const csp = res.headers.get("content-security-policy")!;
+    expect(csp).not.toContain("'unsafe-eval'");
+  });
+
+  test("CSP includes the Convex URL in connect-src", async () => {
+    const res = await middleware(makeReq("/"));
+    const csp = res.headers.get("content-security-policy")!;
+    expect(csp).toContain("https://example.convex.cloud");
+    expect(csp).toContain("wss://example.convex.cloud");
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd apps/web && bun test middleware.test.ts`
+Expected: FAIL — `./middleware` does not exist.
+
+---
+
+## Task 16: Implement `apps/web/middleware.ts`
+
+**Files:**
+- Create: `apps/web/middleware.ts`
+
+- [ ] **Step 1: Write the middleware**
+
+Create `apps/web/middleware.ts`:
+
+```ts
+import { NextResponse, type NextRequest } from "next/server";
+import { envSchema } from "@acme/config/schema";
+
+function makeNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  // base64 without padding
+  return btoa(String.fromCharCode(...bytes)).replace(/=+$/, "");
+}
+
+function convexWss(url: string | undefined): string {
+  if (!url) return "";
+  return url.replace(/^https:/, "wss:").replace(/^http:/, "ws:");
+}
+
+export function middleware(req: NextRequest) {
+  // Parse env per-request — Edge runtime is fast, this keeps test mocking simple.
+  // Production schema enforcement happens at app boot via @acme/config (Node).
+  const env = envSchema.parse({ ...process.env });
+  const nonce = makeNonce();
+  const isProd = env.NODE_ENV === "production";
+  const convexHttp = env.NEXT_PUBLIC_CONVEX_URL ?? "";
+  const convexWs = convexWss(convexHttp);
+
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    !isProd && "'unsafe-eval'"
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const connectSrc = ["'self'", convexHttp, convexWs, !isProd && "ws://localhost:*", !isProd && "http://localhost:*"]
+    .filter(Boolean)
+    .join(" ");
+
+  // TODO(fork): add Stripe (https://js.stripe.com, https://api.stripe.com)
+  // and analytics origins to script-src / connect-src as needed.
+  const csp = [
+    `default-src 'self'`,
+    `script-src ${scriptSrc}`,
+    `style-src 'self' 'nonce-${nonce}'`,
+    `img-src 'self' blob: data:`,
+    `font-src 'self' data:`,
+    `connect-src ${connectSrc}`,
+    `frame-src 'none'`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `frame-ancestors 'none'`,
+    `upgrade-insecure-requests`
+  ].join("; ");
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-nonce", nonce);
+
+  const res = NextResponse.next({ request: { headers: requestHeaders } });
+  res.headers.set("content-security-policy", csp);
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)"]
+};
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cd apps/web && bun test middleware.test.ts`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/middleware.ts apps/web/middleware.test.ts apps/web/package.json
+git commit -m "feat(web): add CSP middleware with per-request nonces"
+```
+
+---
+
+## Task 17: Add `next.config.ts` static headers
+
+**Files:**
+- Create: `apps/web/next.config.ts`
+- Modify: `apps/web/app/layout.tsx`
+
+- [ ] **Step 1: Create `apps/web/next.config.ts`**
+
+```ts
+import type { NextConfig } from "next";
+
+const isProd = process.env.NODE_ENV === "production";
+
+const securityHeaders = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+  },
+  ...(isProd
+    ? [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload"
+        }
+      ]
+    : [])
+];
+
+const config: NextConfig = {
+  async headers() {
+    return [{ source: "/(.*)", headers: securityHeaders }];
+  }
+};
+
+export default config;
+```
+
+- [ ] **Step 2: Wire nonce consumption into `apps/web/app/layout.tsx`**
+
+Replace the file contents with:
+
+```tsx
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { headers } from "next/headers";
+import "@/styles/globals.css";
+
+export const metadata: Metadata = {
+  title: "Composable AI Stack",
+  description: "A production-ready monorepo for building AI-powered applications"
+};
+
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  // Nonce wired via middleware.ts; forks rendering <Script> tags pass this prop.
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+  void nonce;
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck web**
+
+Run: `cd apps/web && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 4: Manual smoke test the headers (optional, requires dev server)**
+
+Run from another shell: `cd apps/web && bun run dev`
+Then: `curl -sI http://localhost:3000 | grep -iE 'content-security-policy|x-frame|referrer|permissions'`
+Expected: CSP header with a nonce, plus the static headers above.
+Stop the dev server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/next.config.ts apps/web/app/layout.tsx
+git commit -m "feat(web): add next.config.ts security headers and nonce consumption in layout"
+```
+
+---
+
+## Task 18: Install Elysia plugins + pino
+
+**Files:**
+- Modify: `apps/api/package.json`
+- Modify: `tooling/scripts/check-versions.ts`
+
+- [ ] **Step 1: Install runtime deps**
+
+Run: `bun add --filter=api @elysiajs/cors@latest @elysiajs/bearer@latest pino@latest`
+
+- [ ] **Step 2: Install dev dep**
+
+Run: `bun add --filter=api -d pino-pretty@latest`
+
+- [ ] **Step 3: Pin exact versions in `apps/api/package.json`**
+
+Replace any `^` or `~` ranges with the exact resolved versions.
+
+- [ ] **Step 4: Add pins to `tooling/scripts/check-versions.ts`**
+
+Extend the `PINS` constant with an `api` block:
+
+```ts
+  api: {
+    dependencies: {
+      elysia: "1.4.22",
+      "@elysiajs/cors": "<resolved>",
+      "@elysiajs/bearer": "<resolved>",
+      pino: "<resolved>"
+    },
+    devDependencies: {
+      "pino-pretty": "<resolved>"
+    }
+  },
+```
+
+Add the corresponding `assertEq` calls at the bottom of the file.
+
+- [ ] **Step 5: Verify pins**
+
+Run: `bun run check:versions`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/package.json tooling/scripts/check-versions.ts bun.lock
+git commit -m "chore(api): install and pin Elysia plugins and pino"
+```
+
+---
+
+## Task 19: Add Elysia logger + security headers + bearer guard + rate limit
+
+**Files:**
+- Create: `apps/api/src/env.ts`
+- Create: `apps/api/src/logger.ts`
+- Create: `apps/api/src/middleware/security-headers.ts`
+- Create: `apps/api/src/middleware/rate-limit.ts`
+- Create: `apps/api/src/middleware/bearer-guard.ts`
+
+- [ ] **Step 1: Create `apps/api/src/env.ts`**
+
+```ts
+export { env } from "@acme/config";
+```
+
+- [ ] **Step 2: Create `apps/api/src/logger.ts`**
+
+```ts
+import pino from "pino";
+import { env } from "./env";
+
+const isProd = env.NODE_ENV === "production";
+
+export const logger = pino({
+  level: env.LOG_LEVEL,
+  redact: {
+    paths: [
+      "req.headers.authorization",
+      "req.headers.cookie",
+      "*.password",
+      "*.token"
+    ],
+    censor: "[redacted]"
+  },
+  transport: isProd
+    ? undefined
+    : { target: "pino-pretty", options: { colorize: true, translateTime: "SYS:HH:MM:ss.l" } }
+});
+```
+
+- [ ] **Step 3: Create `apps/api/src/middleware/security-headers.ts`**
+
+```ts
+import { Elysia } from "elysia";
+import { env } from "../env";
+
+const isProd = env.NODE_ENV === "production";
+
+export const securityHeaders = new Elysia({ name: "security-headers" }).onAfterHandle(
+  ({ set }) => {
+    const headers = (set.headers ??= {});
+    headers["x-content-type-options"] = "nosniff";
+    headers["x-frame-options"] = "DENY";
+    headers["referrer-policy"] = "strict-origin-when-cross-origin";
+    headers["permissions-policy"] = "camera=(), microphone=(), geolocation=(), interest-cohort=()";
+    if (isProd) {
+      headers["strict-transport-security"] = "max-age=63072000; includeSubDomains; preload";
+    }
+  }
+);
+```
+
+- [ ] **Step 4: Create `apps/api/src/middleware/rate-limit.ts`**
+
+```ts
+// In-memory rate limiter. Replace with Redis/Upstash for multi-worker deployments.
+// See README → "Scaling the rate limiter".
+import { Elysia } from "elysia";
+
+type Bucket = { count: number; resetAt: number };
+
+export type RateLimitOptions = {
+  max?: number;
+  windowMs?: number;
+};
+
+export function rateLimit(opts: RateLimitOptions = {}) {
+  const max = opts.max ?? 60;
+  const windowMs = opts.windowMs ?? 60_000;
+  const store = new Map<string, Bucket>();
+
+  return new Elysia({ name: `rate-limit:${max}:${windowMs}` }).onBeforeHandle(
+    ({ request, set }) => {
+      const auth = request.headers.get("authorization");
+      const bearer = auth?.toLowerCase().startsWith("bearer ") ? auth.slice(7) : null;
+      const xff = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+      const key = bearer ?? xff ?? "anonymous";
+
+      const now = Date.now();
+      const bucket = store.get(key);
+      if (!bucket || bucket.resetAt <= now) {
+        store.set(key, { count: 1, resetAt: now + windowMs });
+        set.headers ??= {};
+        set.headers["x-ratelimit-limit"] = String(max);
+        set.headers["x-ratelimit-remaining"] = String(max - 1);
+        set.headers["x-ratelimit-reset"] = String(now + windowMs);
+        set.headers["x-ratelimit-backend"] = "memory";
+        return;
+      }
+      bucket.count += 1;
+      set.headers ??= {};
+      set.headers["x-ratelimit-limit"] = String(max);
+      set.headers["x-ratelimit-remaining"] = String(Math.max(0, max - bucket.count));
+      set.headers["x-ratelimit-reset"] = String(bucket.resetAt);
+      set.headers["x-ratelimit-backend"] = "memory";
+      if (bucket.count > max) {
+        set.status = 429;
+        set.headers["retry-after"] = String(Math.ceil((bucket.resetAt - now) / 1000));
+        return { error: { code: "RATE_LIMITED", message: "too many requests" } };
+      }
+    }
+  );
+}
+```
+
+- [ ] **Step 5: Create `apps/api/src/middleware/bearer-guard.ts`**
+
+```ts
+import { Elysia } from "elysia";
+import { bearer } from "@elysiajs/bearer";
+import { timingSafeEqual } from "node:crypto";
+import { env } from "../env";
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+export const bearerGuard = new Elysia({ name: "bearer-guard" })
+  .use(bearer())
+  .onBeforeHandle(({ bearer, set }) => {
+    if (!env.API_BEARER_TOKEN) {
+      set.status = 500;
+      return { error: { code: "API_BEARER_TOKEN_NOT_CONFIGURED" } };
+    }
+    if (!bearer || !constantTimeEqual(bearer, env.API_BEARER_TOKEN)) {
+      set.status = 401;
+      set.headers ??= {};
+      set.headers["www-authenticate"] = "Bearer";
+      return { error: { code: "UNAUTHORIZED" } };
+    }
+  });
+```
+
+- [ ] **Step 6: Typecheck api**
+
+Run: `cd apps/api && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/env.ts apps/api/src/logger.ts apps/api/src/middleware
+git commit -m "feat(api): add logger, security headers, rate-limit, and bearer guard middleware"
+```
+
+---
+
+## Task 20: Compose Elysia app + graceful shutdown
+
+**Files:**
+- Modify: `apps/api/src/index.ts`
+
+- [ ] **Step 1: Replace `apps/api/src/index.ts`**
+
+```ts
+import { Elysia } from "elysia";
+import { cors } from "@elysiajs/cors";
+import { env } from "./env";
+import { logger } from "./logger";
+import { securityHeaders } from "./middleware/security-headers";
+import { rateLimit } from "./middleware/rate-limit";
+import { bearerGuard } from "./middleware/bearer-guard";
+
+function mapStatus(code: string): number {
+  switch (code) {
+    case "VALIDATION":
+    case "PARSE":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    default:
+      return 500;
+  }
+}
+
+const app = new Elysia()
+  .use(securityHeaders)
+  .use(
+    cors({
+      origin: env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+      credentials: true,
+      methods: ["GET", "POST", "OPTIONS"],
+      allowedHeaders: ["authorization", "content-type"]
+    })
+  )
+  .onRequest(({ request }) => {
+    logger.info({ method: request.method, url: request.url }, "request");
+  })
+  .onError(({ error, code, set }) => {
+    logger.error({ err: error, code }, "error");
+    set.status = mapStatus(code);
+    return {
+      error: {
+        code,
+        message: env.NODE_ENV === "production" ? "internal error" : String((error as Error)?.message ?? error)
+      }
+    };
+  })
+  .get("/health", () => ({ ok: true }))
+  .group("/protected", (a) =>
+    a
+      .use(bearerGuard)
+      .use(rateLimit({ max: 60, windowMs: 60_000 }))
+      .get("/me", () => ({ ok: true }))
+  )
+  .listen({ port: env.API_PORT, hostname: "0.0.0.0" });
+
+logger.info({ port: env.API_PORT }, "api listening");
+
+const drain = async () => {
+  logger.info("draining…");
+  await app.stop();
+  process.exit(0);
+};
+process.on("SIGTERM", drain);
+process.on("SIGINT", drain);
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd apps/api && bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 3: Manual smoke test (optional, requires API_BEARER_TOKEN set)**
+
+```bash
+API_BEARER_TOKEN=$(printf 'a%.0s' {1..32}) NEXT_PUBLIC_APP_URL=http://localhost:3000 NODE_ENV=development bun apps/api/src/index.ts &
+API_PID=$!
+sleep 1
+curl -s -i http://localhost:3001/health
+curl -s -i http://localhost:3001/protected/me
+curl -s -i -H "Authorization: Bearer $(printf 'a%.0s' {1..32})" http://localhost:3001/protected/me
+kill $API_PID
+```
+Expected: `/health` → 200; `/protected/me` without bearer → 401; with bearer → 200; both 401 and 200 responses include `X-Content-Type-Options: nosniff` and `X-RateLimit-Backend: memory`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/index.ts
+git commit -m "feat(api): compose hardened Elysia app with bearer guard, rate limit, and graceful shutdown"
+```
+
+---
+
+## Task 21: Rewrite `.env.example` + add `apps/web/.env.local.example`
+
+**Files:**
+- Modify: `.env.example`
+- Create: `apps/web/.env.local.example`
+
+- [ ] **Step 1: Replace `.env.example` contents**
+
+```dotenv
+# ─── Required in production ────────────────────────────────────
+NODE_ENV=development
+
+# Convex — from `bunx convex dev` output
+CONVEX_DEPLOYMENT=
+NEXT_PUBLIC_CONVEX_URL=
+
+# Web app origin (used by API CORS + CSP connect-src)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Stripe — required for the webhook handler
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Elysia gateway
+API_BEARER_TOKEN=
+API_PORT=3001
+
+# ─── Optional ──────────────────────────────────────────────────
+WEBHOOK_TOLERANCE_SECONDS=300
+LOG_LEVEL=info
+
+# ⚠️ NEVER commit a real .env file. For Convex secrets, use
+#    `bunx convex env set <NAME> <VALUE>` — they live in the Convex
+#    dashboard, not in this file.
+```
+
+- [ ] **Step 2: Create `apps/web/.env.local.example`**
+
+```dotenv
+# Public envs only — these are inlined into the client bundle.
+NEXT_PUBLIC_CONVEX_URL=
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .env.example apps/web/.env.local.example
+git commit -m "docs: rewrite .env.example with Foundation envs and add web .env.local.example"
+```
+
+---
+
+## Task 22: README — "Scaling the rate limiter" section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a new subsection**
+
+Open `README.md`. Locate the section that mentions Elysia (search for `## When to use ElysiaJS` or the `apps/api` description). Below it, add:
+
+```markdown
+## Scaling the rate limiter
+
+`apps/api` ships an in-memory rate limiter (`apps/api/src/middleware/rate-limit.ts`).
+It tracks request counts in a single-process `Map`. For multi-worker or multi-instance
+deployments, replace the backing store with Redis or Upstash:
+
+1. Install: `bun add --filter=api @upstash/ratelimit @upstash/redis`
+2. Swap the `Map` in `rate-limit.ts` for an Upstash `Ratelimit` instance.
+3. Set `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in `.env`.
+
+The middleware exposes `X-RateLimit-Backend: memory` so you can verify which store
+is in use at runtime.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add 'Scaling the rate limiter' section to README"
+```
+
+---
+
+## Task 23: Final acceptance check
+
+- [ ] **Step 1: Run typecheck across the repo**
+
+Run: `bun run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 2: Run version pin check**
+
+Run: `bun run check:versions`
+Expected: exits 0.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `bun run test`
+Expected: all suites pass (config schema, convex withUser, convex webhook, web middleware).
+
+- [ ] **Step 4: Convex schema dry-run (if `CONVEX_DEPLOYMENT` is set)**
+
+Run: `cd apps/convex && bunx convex deploy --dry-run`
+Expected: no schema errors.
+
+- [ ] **Step 5: Confirm acceptance criteria from the spec**
+
+Walk through `docs/superpowers/specs/2026-05-12-foundation-hardening-design.md` § "Acceptance criteria" and check each:
+- `bun run typecheck` ✓
+- `bun run test` (4 suites pass) ✓
+- `bunx convex deploy --dry-run` ✓ (if env is set)
+- `bun run check:versions` ✓
+- Manual Stripe webhook checks (covered by tests) ✓
+- Manual CSP header check (covered by middleware test) ✓
+- Manual Elysia 401/200/429 (covered by step 3 of Task 20) ✓
+
+- [ ] **Step 6: Final commit (only if any incidental files changed)**
+
+```bash
+git status
+# If clean, no commit. Otherwise commit incidental fixes individually.
+```
+
+---
+
+## Spec coverage table
+
+| Spec section | Tasks |
+|---|---|
+| Section 1 — `packages/config` env module | 1, 2, 3, 4, 5 |
+| Section 2 — Stripe webhook (Convex) | 7, 11, 12, 13, 14 |
+| Section 3 — Convex Auth + schema columns | 6, 7, 8, 9, 10 |
+| Section 4 — Next.js security headers + CSP nonces | 15, 16, 17 |
+| Section 5 — Elysia hardening | 18, 19, 20 |
+| Section 6 — `.env.example` | 21 |
+| Section 7 — Tests | 2 (config), 9 (withUser), 12 (webhook), 15 (middleware) |
+| README scaling note | 22 |
+| Acceptance | 23 |

--- a/docs/superpowers/specs/2026-05-12-foundation-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-12-foundation-hardening-design.md
@@ -1,0 +1,345 @@
+# Foundation Hardening — Design
+
+**Date:** 2026-05-12
+**Scope:** Sub-project 1 of 6 from the `/audit composable-ai-stack` follow-up.
+**Goal:** make the template's defaults safe to fork. Close the Critical and High security findings from the audit, and put env validation + Convex auth in place so every later sub-project can build on a real foundation.
+
+## Out of scope
+
+- `packages/prompts` runtime, `packages/ai` typed tools, `packages/evals` harness, `packages/schemas` base — Sub-project 2 (AI runtime core).
+- `conversations`, `messages`, `toolCalls`, `evalRuns`, `promptVersions` tables and multi-tenant `workspaceId` columns — Sub-project 3 (Convex AI schema).
+- Chat demo, `next-themes`, loading/error/not-found pages, `<nav>` header, SSE endpoint — Sub-project 4 (App shell + chat demo).
+- Landing-page token migration, `next/font`, brand differentiation, button hover fix — Sub-project 5 (Landing polish).
+- Root `package.json` rename, `@acme/*` → `@cas/*` rename, `apps/api/package.json` lint placeholder, `package.json` `exports` fields, `check-versions.ts` `import.meta.dir` fix — Sub-project 6 (DX cleanup).
+
+## Decisions (locked)
+
+- **Env strictness:** strict by `NODE_ENV` — required in `production`, optional in `development`/`test`. Throws at module load.
+- **Stripe scope:** verify signature + raw body + replay window + idempotency table, plus minimal sync of `customer.subscription.{created,updated,deleted}` to `users.planStatus`/`users.plan`.
+- **Auth provider:** `@convex-dev/auth` with the `Password` provider as the only built-in. Other providers documented but not wired.
+- **CSP:** strict directives with per-request nonces issued by `apps/web/middleware.ts`. `'strict-dynamic'` for scripts, nonced styles.
+- **Elysia surface:** hardened skeleton — CORS, security headers, structured logger, bearer guard on `/protected/*`, in-memory rate limit, `onError`, graceful shutdown, `PORT` from env. No SSE.
+- **Rate-limit store:** in-memory `Map` with `X-RateLimit-Backend: memory` and a swap-to-Redis comment + README note.
+- **Tests:** Bun test suites covering env loader, Stripe webhook, `withUser` helper, and CSP middleware.
+- **`.env.example`:** Foundation-only envs (Convex, Stripe, app URL, API bearer/port, log level, webhook tolerance). No AI provider keys yet.
+- **Env architecture:** shared Zod schema in `packages/config`, two parse sites — Node loader for Next/Elysia/Worker, Convex-side loader in `apps/convex/convex/_lib/env.ts`.
+
+## Section 1 — `packages/config` env module
+
+### Files
+
+- `packages/config/src/schema.ts` — exports `envSchema` (Zod) and `parseEnv(input, mode)`. Pure, no I/O, no Node-only imports. Safe to import from the Convex runtime.
+- `packages/config/src/node.ts` — Node loader: `import "dotenv/config"` (dev only, guarded on `NODE_ENV !== "production"`), then `parseEnv(process.env, process.env.NODE_ENV)`, throws on failure. Exports typed `env`.
+- `packages/config/src/index.ts` — re-exports from `node.ts`. The default import path for Next/Elysia/Worker.
+- `apps/convex/convex/_lib/env.ts` — imports `envSchema` from `@cas/config/schema`, runs `.parse(process.env)` inside the Convex runtime, exports typed `env`. Convex functions import from here, never from `@cas/config`.
+
+### Schema fields
+
+| Field | Type | Required in production | Default |
+|---|---|---|---|
+| `NODE_ENV` | `"development"\|"test"\|"production"` | always | — |
+| `STRIPE_SECRET_KEY` | string | yes | — |
+| `STRIPE_WEBHOOK_SECRET` | string | yes | — |
+| `CONVEX_DEPLOYMENT` | string | yes | — |
+| `NEXT_PUBLIC_CONVEX_URL` | URL string | yes | — |
+| `NEXT_PUBLIC_APP_URL` | URL string | yes | — |
+| `API_BEARER_TOKEN` | string (min 32) | yes | — |
+| `WEBHOOK_TOLERANCE_SECONDS` | number coerced from string | no | `300` |
+| `API_PORT` | number coerced from string | no | `3001` |
+| `LOG_LEVEL` | `"debug"\|"info"\|"warn"\|"error"` | no | `"info"` |
+
+### Behavior
+
+- `parseEnv` uses `envSchema.superRefine` to enforce required-in-production fields conditionally on the `mode` argument.
+- `node.ts` calls `parseEnv` once at module load. The resulting `env` is frozen with `Object.freeze`.
+- Parse errors throw with the Zod issue path so missing/invalid fields are named in the stack trace.
+
+### Dependencies (pinned)
+
+- `zod@3.23.8` added to `packages/config/package.json`.
+- `dotenv@16.4.7` added to `packages/config/package.json`.
+- Both names added to `tooling/scripts/check-versions.ts` so version drift fails CI.
+
+## Section 2 — Stripe webhook (Convex)
+
+### Replaces
+
+`apps/convex/convex/http.ts:8-14` — the 200-without-verify stub.
+
+### New files
+
+- `apps/convex/convex/_lib/stripe.ts` — `getStripe()` returns a lazy-initialized `Stripe` client using `env.STRIPE_SECRET_KEY`. `apiVersion` pinned to the current Stripe SDK default for the pinned `stripe` dep.
+- `apps/convex/convex/_lib/env.ts` — Convex-side env loader (Section 1).
+- `apps/convex/convex/stripe.ts` — internal mutations:
+  - `recordEvent(eventId, type)` — inserts into `processedStripeEvents`; returns `false` if duplicate via unique index.
+  - `applySubscriptionChange({ stripeCustomerId, status, plan })` — looks up user by `stripeCustomerId`, writes `planStatus`, `plan`, `planUpdatedAt`.
+
+### Handler shape
+
+`apps/convex/convex/http.ts` registers `POST /stripe/webhook`:
+
+1. `const body = await request.text();` — raw body, never `.json()`.
+2. Read `Stripe-Signature` header. Missing → return `400`.
+3. `stripe.webhooks.constructEvent(body, sig, env.STRIPE_WEBHOOK_SECRET, env.WEBHOOK_TOLERANCE_SECONDS)` inside `try/catch`. `StripeSignatureVerificationError` → `400`.
+4. `await ctx.runMutation(internal.stripe.recordEvent, { eventId, type })`. Returns `false` if already processed → respond `200` immediately (idempotent replay).
+5. Switch on `event.type`:
+   - `customer.subscription.created`, `customer.subscription.updated` → `applySubscriptionChange({ stripeCustomerId, status: subscription.status, plan: subscription.items.data[0]?.price.lookup_key ?? subscription.items.data[0]?.price.id })`.
+   - `customer.subscription.deleted` → `applySubscriptionChange({ stripeCustomerId, status: "canceled", plan: null })`.
+   - Anything else → log `"unhandled event type"` with the type, return `200`.
+6. Return `200` with `{ received: true }`.
+
+### Schema additions (`apps/convex/convex/schema.ts`)
+
+- New table `processedStripeEvents`:
+  - `eventId: v.string()`
+  - `type: v.string()`
+  - `processedAt: v.number()`
+  - Index `by_eventId` on `["eventId"]`. Convex has no unique-index constraint, so `recordEvent` does a "read by index, return false if found, else insert" inside one mutation. Concurrent webhook deliveries for the same `eventId` could theoretically both pass the read and both insert; in practice Stripe retries are sequential, not concurrent, so the race is acceptable for a template. Forks needing strict uniqueness can switch to a `withIndex` + transactional check pattern.
+- `users` table gains:
+  - `plan: v.optional(v.string())`
+  - `planUpdatedAt: v.optional(v.number())`
+
+`stripeCustomerId` and `planStatus` already exist on `users` and are reused.
+
+### Failure modes
+
+- Invalid signature → `400`, no DB write.
+- Missing required env → `_lib/env.ts` throws at module load; the deploy fails before any request lands.
+- Unknown event type → `200`, logged at `info`. Stripe expects 2xx for unhandled types or it will retry indefinitely.
+- Convex mutation conflict (rare) → bubbles up as `500`; Stripe will retry per its standard backoff.
+
+### Dependencies (pinned)
+
+- `stripe@<pinned version>` added to `apps/convex/package.json`. Added to `check-versions.ts`.
+
+## Section 3 — Convex Auth pattern + schema columns
+
+### New files
+
+- `apps/convex/convex/auth.ts` — calls `convexAuth({ providers: [Password] })` and re-exports `auth.addHttpRoutes`, `getAuthUserId`, `store`. Comment block points at Convex Auth docs for adding GitHub/Google/etc.
+- `apps/convex/convex/auth.config.ts` — required Convex Auth config; `providers: [{ domain: process.env.SITE_URL!, applicationID: "convex" }]` per Convex Auth convention. `SITE_URL` is a Convex-runtime-only env set via `bunx convex env set SITE_URL <url>`; it is **not** part of `@cas/config`'s schema because it never reaches Next/Elysia/Worker.
+- `apps/convex/convex/_lib/withUser.ts` — guard helpers:
+  - `requireUser(ctx)` → returns `userId` or throws `ConvexError({ code: "UNAUTHENTICATED" })`.
+  - `requireUserDoc(ctx)` → `requireUser` plus `ctx.db.get(userId)` with a not-found throw.
+- `apps/convex/convex/users.ts` — example authenticated functions:
+  - `query me()` → returns `requireUserDoc(ctx)`.
+  - `mutation updateProfile({ name })` → `requireUser`, validates with `v.string()`, writes `name` to the user doc.
+
+### `http.ts` change
+
+The same `http` router that mounts the Stripe webhook calls `auth.addHttpRoutes(http)`. Stripe stays unauthenticated (Stripe signs it); auth routes mount under `/api/auth/*`. The two coexist on one router.
+
+### Schema additions
+
+- `users` table gains:
+  - `tokenIdentifier: v.optional(v.string())` (set by Convex Auth on signup)
+  - `name: v.optional(v.string())`
+  - `image: v.optional(v.string())`
+- New index `by_token` on `["tokenIdentifier"]`.
+- The Convex Auth tables (`authSessions`, `authAccounts`, `authVerificationCodes`, `authVerifiers`, `authRateLimits`) are spread in via `...authTables` per Convex Auth convention.
+
+### Multi-tenant deferred
+
+`workspaceId` columns and tenant-scoped queries are explicitly out of scope. Every query in this pass is scoped by `userId`. Sub-project 3 introduces tenancy.
+
+### Dependencies (pinned)
+
+- `@convex-dev/auth@<latest>` added to `apps/convex/package.json`. `@auth/core` as a peer if required by the version. Added to `check-versions.ts`.
+
+## Section 4 — Next.js security headers + CSP nonces
+
+### New files
+
+- `apps/web/middleware.ts`
+  - Generates per-request nonce: 16 random bytes via `crypto.getRandomValues`, base64.
+  - Sets request header `x-nonce` (consumed in RSC via `headers()`).
+  - Sets response `Content-Security-Policy` with the nonce interpolated.
+  - `config.matcher` excludes `/_next/static`, `/_next/image`, `/favicon.ico`, and the `/public` paths.
+- `apps/web/next.config.ts`
+  - `async headers()` returning the static headers that don't need a nonce.
+  - Conditional HSTS only when `NODE_ENV === "production"`.
+
+### CSP directives — production
+
+```
+default-src 'self';
+script-src 'self' 'nonce-{n}' 'strict-dynamic';
+style-src 'self' 'nonce-{n}';
+img-src 'self' blob: data:;
+font-src 'self' data:;
+connect-src 'self' {NEXT_PUBLIC_CONVEX_URL} {wss equivalent};
+frame-src 'none';
+object-src 'none';
+base-uri 'self';
+form-action 'self';
+frame-ancestors 'none';
+upgrade-insecure-requests;
+```
+
+Stripe and analytics origins deliberately omitted — left as a `// TODO(fork):` comment in `middleware.ts` so forks add the origins they actually need.
+
+### CSP directives — development
+
+Same as production with two relaxations:
+
+- `script-src` adds `'unsafe-eval'` (Next/React HMR requires it).
+- `connect-src` adds `ws://localhost:*` and `http://localhost:*`.
+
+`middleware.ts` runs in the Edge runtime, which forbids Node-only APIs. It must import from `@cas/config/schema` (the pure Zod module), **not** from `@cas/config` (the Node loader uses `dotenv`). The middleware calls `envSchema.parse(process.env)` directly. `process.env` is available in the Edge runtime; `dotenv` is not.
+
+### Static headers (`next.config.ts`)
+
+- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (prod only)
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()`
+- `X-Frame-Options: DENY` (defense in depth alongside `frame-ancestors 'none'`)
+
+### Nonce consumption
+
+`apps/web/app/layout.tsx` reads `headers().get("x-nonce")` and passes it to any `<Script>` it renders. The current landing has no third-party scripts, so the wiring exists but is unused — ready for forks.
+
+## Section 5 — Elysia hardening (`apps/api`)
+
+### Replaces
+
+`apps/api/src/index.ts:7-9` — `/health` only, hardcoded port `3001`.
+
+### File layout
+
+- `apps/api/src/env.ts` — re-exports `env` from `@cas/config`. Keeps imports stable.
+- `apps/api/src/logger.ts` — `pino` instance. `level: env.LOG_LEVEL`. `pino-pretty` transport when `NODE_ENV !== "production"`. Redacts `req.headers.authorization`, `req.headers.cookie`, and any `*.password` field.
+- `apps/api/src/middleware/security-headers.ts` — Elysia plugin setting `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and HSTS in prod. (Equivalent to a helmet subset; in-repo to avoid pinning another plugin.)
+- `apps/api/src/middleware/rate-limit.ts` — in-memory limiter:
+  - `Map<string, { count: number; resetAt: number }>` keyed by `bearer ?? ip`. IP from `request.headers.get("x-forwarded-for")?.split(",")[0].trim()` or `server.requestIP(request)?.address`.
+  - Defaults: 60 s window, 60 requests per window. Configurable per route via plugin options.
+  - Sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `X-RateLimit-Backend: memory`.
+  - On breach: `429` with `Retry-After`.
+  - File header comment: "Replace with Redis/Upstash for multi-worker deployments. See README." README gets a `## Scaling the rate limiter` subsection.
+- `apps/api/src/middleware/bearer-guard.ts` — wraps `@elysiajs/bearer`. Constant-time compare via `crypto.timingSafeEqual` over Buffer-wrapped tokens of equal length. Reject `401` on mismatch or missing token.
+- `apps/api/src/index.ts` — composes the app:
+  - `.use(securityHeaders)`
+  - `.use(cors({ origin: env.NEXT_PUBLIC_APP_URL, credentials: true, methods: ["GET","POST","OPTIONS"], allowedHeaders: ["authorization","content-type"] }))`
+  - `.onRequest(({ request }) => logger.info({ method: request.method, url: request.url, reqId }))`
+  - `.onError(({ error, code, set }) => { logger.error({ err: error, code }); set.status = mapCode(code); return { error: { code, message: prodSafeMessage(error) } }; })`
+  - `.get("/health", () => ({ ok: true }))`
+  - `.group("/protected", a => a.use(bearerGuard).use(rateLimit({ max: 60, windowMs: 60_000 })).get("/me", ({ bearer }) => ({ token: "ok" })))`
+  - `.listen({ port: env.API_PORT, hostname: "0.0.0.0" })`
+- **Graceful shutdown:** `process.on("SIGTERM", () => app.stop())` and `SIGINT` handler. 10 s drain timeout.
+
+### Error mapping
+
+- `VALIDATION` → 400
+- `NOT_FOUND` → 404
+- `PARSE` → 400
+- everything else → 500
+
+Response body shape: `{ error: { code, message } }`. Stack traces only logged server-side.
+
+### Dependencies (pinned)
+
+Added to `apps/api/package.json` and `check-versions.ts`:
+
+- `@elysiajs/cors@<latest>`
+- `@elysiajs/bearer@<latest>`
+- `pino@<latest>`
+- `pino-pretty@<latest>` (devDependency)
+
+## Section 6 — `.env.example` rewrite
+
+```dotenv
+# ─── Required in production ────────────────────────────────────
+NODE_ENV=development
+
+# Convex — from `bunx convex dev` output
+CONVEX_DEPLOYMENT=
+NEXT_PUBLIC_CONVEX_URL=
+
+# Web app origin (used by API CORS + CSP connect-src)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Stripe — required for the webhook handler
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Elysia gateway
+API_BEARER_TOKEN=
+API_PORT=3001
+
+# ─── Optional ──────────────────────────────────────────────────
+WEBHOOK_TOLERANCE_SECONDS=300
+LOG_LEVEL=info
+
+# ⚠️ NEVER commit a real .env file. For Convex secrets, use
+#    `bunx convex env set <NAME> <VALUE>` — they live in the Convex
+#    dashboard, not in this file.
+```
+
+`apps/web/.env.local.example` mirrors only the `NEXT_PUBLIC_*` subset (Next.js convention).
+
+## Section 7 — Tests
+
+All tests live in the workspace they verify. Each workspace gets `"test": "bun test"` in its `package.json`. `turbo.json:27` already declares the `test` task; this pass makes it do real work.
+
+### `packages/config/src/schema.test.ts`
+
+- Valid dev env → returns typed object with defaults applied.
+- `NODE_ENV=production` + missing `STRIPE_SECRET_KEY` → throws; error message names the field.
+- Optional fields apply defaults: `WEBHOOK_TOLERANCE_SECONDS=300`, `API_PORT=3001`, `LOG_LEVEL=info`.
+- Invalid `NODE_ENV` value → throws.
+
+### `apps/convex/convex/http.test.ts` (uses `convex-test`)
+
+- POST `/stripe/webhook` with no `Stripe-Signature` → `400`.
+- POST with valid-looking signature but tampered body → `400`.
+- POST with valid signature and fresh `event.id` → `200`; `processedStripeEvents` row written; `users.planStatus` updated.
+- POST with valid signature and replayed `event.id` → `200`; no second write (idempotent).
+- `customer.subscription.deleted` → `planStatus: "canceled"`, `plan: null`.
+
+### `apps/convex/convex/_lib/withUser.test.ts` (uses `convex-test`)
+
+- `requireUser` without identity → throws `UNAUTHENTICATED`.
+- `requireUser` with identity → returns `userId`.
+- `users.me` as anon → throws; as authed → returns user doc.
+
+### `apps/web/middleware.test.ts` (Bun test + mock `NextRequest`)
+
+- Response sets `Content-Security-Policy`; nonce appears in both `script-src` and `style-src`.
+- Production CSP contains HSTS-relevant directives and omits `'unsafe-eval'`.
+- Development CSP contains `'unsafe-eval'` and `ws://localhost:*`.
+- Matcher excludes `/_next/static/...`.
+
+### Out of scope for this pass
+
+Elysia integration tests for rate-limit + bearer (would require booting a real listener). Type composition + middleware unit coverage is sufficient for the template pass.
+
+## Migration / order of operations
+
+This is a greenfield template, so there is no data to migrate. Implementation order matters for cross-section dependencies:
+
+1. Section 1 (`packages/config`) lands first — every other section imports `env`.
+2. Section 3 (Convex Auth) lands before Section 2 (Stripe webhook) because the webhook touches the `users` schema and tests sit alongside auth tests; doing auth first avoids re-touching `schema.ts`.
+3. Section 4 (Next.js headers) and Section 5 (Elysia) are independent and can land in either order.
+4. Section 6 (`.env.example`) lands last so it reflects the final shape.
+5. Section 7 (tests) is interleaved — each suite lands with its corresponding section.
+
+## Version pinning
+
+The spec lists deps without exact versions because the repo's `check-versions.ts` enforces pins centrally. The implementing pass picks the current latest stable for each new dep at the moment of writing, adds it to the relevant `package.json` with an exact pin (no `^` or `~`), and extends `tooling/scripts/check-versions.ts`'s allow-list to cover it. The spec calls out which deps are new; the version numbers are chosen at implementation time and reviewed alongside the code.
+
+## Risks
+
+- **Convex Auth `Password` provider UX:** users will need a sign-up flow on the web side to exercise auth. This template has no such page yet (Sub-project 4 adds it). Foundation ships the backend; forks can curl `/api/auth/*` to test until Sub-project 4 lands.
+- **CSP and the existing landing page:** the landing uses `globals.css` and a few inline `style={{...}}` props for animations. Inline styles will need nonces or hash allowances. Inventory inline-style sites during implementation; if more than a couple, switch them to Tailwind utilities before turning CSP on in prod.
+- **Stripe SDK version pinning:** the `apiVersion` constant in `_lib/stripe.ts` must match the pinned `stripe` package's default to avoid surprise behavior changes when bumping. Add a comment to that line.
+- **In-memory rate limit + multi-worker Bun:** Bun's `--smol` and clustered deployments will not share state. This is acknowledged via the `X-RateLimit-Backend: memory` header and README note; not fixed here.
+
+## Acceptance criteria
+
+- `bun run typecheck` passes.
+- `bun run test` runs and the four new test suites pass.
+- `bunx convex deploy --dry-run` succeeds against the new schema.
+- `bun run check:versions` passes with the new pins.
+- Manual: POSTing to the Stripe webhook without a signature returns `400`. POSTing with a valid CLI-generated signature returns `200`.
+- Manual: hitting `apps/web` in dev shows a `Content-Security-Policy` response header with a fresh nonce per refresh.
+- Manual: hitting `apps/api`'s `/protected/me` without a bearer returns `401`; with the right token returns `200`; >60 req/min returns `429`.

--- a/docs/superpowers/specs/2026-05-12-foundation-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-12-foundation-hardening-design.md
@@ -161,7 +161,7 @@ The same `http` router that mounts the Stripe webhook calls `auth.addHttpRoutes(
 
 ### CSP directives — production
 
-```
+```text
 default-src 'self';
 script-src 'self' 'nonce-{n}' 'strict-dynamic';
 style-src 'self' 'nonce-{n}';

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ai-swiss-army-template",
+  "version": "0.1.0",
   "private": true,
   "packageManager": "bun@1.3.7",
   "workspaces": [
@@ -28,5 +29,8 @@
     "prettier": "3.8.1",
     "turbo": "2.7.6",
     "typescript": "5.9.3"
+  },
+  "dependencies": {
+    "zod": "3.23.8"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
-  "dependencies": {},
+  "dependencies": {
+    "dotenv": "16.4.7",
+    "zod": "3.23.8"
+  },
   "devDependencies": {
     "typescript": "5.9.3"
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -2,6 +2,10 @@
   "name": "@acme/config",
   "private": true,
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema.ts"
+  },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "bun test"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "dotenv": "16.4.7",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,2 +1,3 @@
-// config package entry
-export {};
+export { env } from "./node";
+export type { Env, Mode } from "./schema";
+export { envSchema, parseEnv } from "./schema";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,5 @@
+// Node-runtime entrypoint. Importing this module runs parseEnv against
+// process.env at load time. For pure schema access (no side effects),
+// import from "@acme/config/schema".
 export { env } from "./node";
 export type { Env, Mode } from "./schema";
-export { envSchema, parseEnv } from "./schema";

--- a/packages/config/src/node.ts
+++ b/packages/config/src/node.ts
@@ -1,0 +1,14 @@
+import { parseEnv, type Env } from "./schema";
+
+if (process.env.NODE_ENV !== "production") {
+  // Best-effort .env loading in non-prod; ignore if dotenv is absent.
+  try {
+    const dotenv = await import("dotenv");
+    dotenv.config();
+  } catch {
+    // dotenv is an optional runtime convenience; production deploys inject env directly.
+  }
+}
+
+const mode = process.env.NODE_ENV ?? "development";
+export const env: Env = Object.freeze(parseEnv(process.env, mode));

--- a/packages/config/src/node.ts
+++ b/packages/config/src/node.ts
@@ -1,12 +1,14 @@
 import { parseEnv, type Env } from "./schema";
 
 if (process.env.NODE_ENV !== "production") {
-  // Best-effort .env loading in non-prod; ignore if dotenv is absent.
   try {
     const dotenv = await import("dotenv");
     dotenv.config();
-  } catch {
-    // dotenv is an optional runtime convenience; production deploys inject env directly.
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") {
+      console.warn("[@acme/config] dotenv load failed:", err);
+    }
   }
 }
 

--- a/packages/config/src/schema.test.ts
+++ b/packages/config/src/schema.test.ts
@@ -41,6 +41,12 @@ describe("parseEnv", () => {
     expect(() => parseEnv({ NODE_ENV: "staging" }, "staging")).toThrow(/NODE_ENV/);
   });
 
+  test("rejects invalid NEXT_PUBLIC_CONVEX_URL", () => {
+    expect(() =>
+      parseEnv({ ...validProd, NEXT_PUBLIC_CONVEX_URL: "not-a-url" }, "production")
+    ).toThrow(/NEXT_PUBLIC_CONVEX_URL/);
+  });
+
   test("coerces numeric string envs", () => {
     const env = parseEnv(
       { NODE_ENV: "development", API_PORT: "4000", WEBHOOK_TOLERANCE_SECONDS: "60" },

--- a/packages/config/src/schema.test.ts
+++ b/packages/config/src/schema.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, describe } from "bun:test";
+import { parseEnv } from "./schema";
+
+const validProd = {
+  NODE_ENV: "production",
+  STRIPE_SECRET_KEY: "sk_test_x",
+  STRIPE_WEBHOOK_SECRET: "whsec_x",
+  CONVEX_DEPLOYMENT: "dev:abc",
+  NEXT_PUBLIC_CONVEX_URL: "https://example.convex.cloud",
+  NEXT_PUBLIC_APP_URL: "https://app.example.com",
+  API_BEARER_TOKEN: "a".repeat(32)
+};
+
+describe("parseEnv", () => {
+  test("parses a valid dev env and applies defaults", () => {
+    const env = parseEnv({ NODE_ENV: "development" }, "development");
+    expect(env.NODE_ENV).toBe("development");
+    expect(env.WEBHOOK_TOLERANCE_SECONDS).toBe(300);
+    expect(env.API_PORT).toBe(3001);
+    expect(env.LOG_LEVEL).toBe("info");
+  });
+
+  test("parses a valid production env with all required fields", () => {
+    const env = parseEnv(validProd, "production");
+    expect(env.STRIPE_SECRET_KEY).toBe("sk_test_x");
+    expect(env.API_BEARER_TOKEN.length).toBe(32);
+  });
+
+  test("rejects production env missing STRIPE_SECRET_KEY", () => {
+    const { STRIPE_SECRET_KEY: _, ...partial } = validProd;
+    expect(() => parseEnv(partial, "production")).toThrow(/STRIPE_SECRET_KEY/);
+  });
+
+  test("rejects production env with too-short API_BEARER_TOKEN", () => {
+    expect(() =>
+      parseEnv({ ...validProd, API_BEARER_TOKEN: "short" }, "production")
+    ).toThrow(/API_BEARER_TOKEN/);
+  });
+
+  test("rejects invalid NODE_ENV value", () => {
+    expect(() => parseEnv({ NODE_ENV: "staging" }, "staging")).toThrow(/NODE_ENV/);
+  });
+
+  test("coerces numeric string envs", () => {
+    const env = parseEnv(
+      { NODE_ENV: "development", API_PORT: "4000", WEBHOOK_TOLERANCE_SECONDS: "60" },
+      "development"
+    );
+    expect(env.API_PORT).toBe(4000);
+    expect(env.WEBHOOK_TOLERANCE_SECONDS).toBe(60);
+  });
+});

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+export type Mode = "development" | "test" | "production";
+
+const optionalUrl = z.string().url().optional();
+const optionalStr = z.string().optional();
+
+export const envSchema = z
+  .object({
+    NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+
+    STRIPE_SECRET_KEY: optionalStr,
+    STRIPE_WEBHOOK_SECRET: optionalStr,
+    CONVEX_DEPLOYMENT: optionalStr,
+    NEXT_PUBLIC_CONVEX_URL: optionalUrl,
+    NEXT_PUBLIC_APP_URL: optionalUrl,
+    API_BEARER_TOKEN: z.string().min(32).optional(),
+
+    WEBHOOK_TOLERANCE_SECONDS: z.coerce.number().int().positive().default(300),
+    API_PORT: z.coerce.number().int().positive().default(3001),
+    LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info")
+  })
+  .superRefine((env, ctx) => {
+    if (env.NODE_ENV !== "production") return;
+    const requiredInProd: Array<keyof typeof env> = [
+      "STRIPE_SECRET_KEY",
+      "STRIPE_WEBHOOK_SECRET",
+      "CONVEX_DEPLOYMENT",
+      "NEXT_PUBLIC_CONVEX_URL",
+      "NEXT_PUBLIC_APP_URL",
+      "API_BEARER_TOKEN"
+    ];
+    for (const key of requiredInProd) {
+      if (!env[key]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `${key} is required when NODE_ENV=production`
+        });
+      }
+    }
+  });
+
+export type Env = z.infer<typeof envSchema>;
+
+export function parseEnv(input: Record<string, unknown>, mode: string): Env {
+  const candidate = { ...input, NODE_ENV: mode ?? input.NODE_ENV };
+  const result = envSchema.safeParse(candidate);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    throw new Error(`Invalid environment: ${detail}`);
+  }
+  return result.data;
+}

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -35,7 +35,7 @@ export const envSchema = z
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: [key],
-          message: `${key} is required when NODE_ENV=production`
+          message: `Required when NODE_ENV=production`
         });
       }
     }
@@ -43,8 +43,8 @@ export const envSchema = z
 
 export type Env = z.infer<typeof envSchema>;
 
-export function parseEnv(input: Record<string, unknown>, mode: string): Env {
-  const candidate = { ...input, NODE_ENV: mode ?? input.NODE_ENV };
+export function parseEnv(input: Record<string, unknown>, mode: Mode | string): Env {
+  const candidate = { ...input, NODE_ENV: mode };
   const result = envSchema.safeParse(candidate);
   if (!result.success) {
     const detail = result.error.issues

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -17,7 +17,7 @@ export const envSchema = z
     API_BEARER_TOKEN: z.string().min(32).optional(),
 
     WEBHOOK_TOLERANCE_SECONDS: z.coerce.number().int().positive().default(300),
-    API_PORT: z.coerce.number().int().positive().default(3001),
+    API_PORT: z.coerce.number().int().min(1).max(65535).default(3001),
     LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info")
   })
   .superRefine((env, ctx) => {

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": [
     "src"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
   ]
 }

--- a/tooling/scripts/check-versions.ts
+++ b/tooling/scripts/check-versions.ts
@@ -71,7 +71,7 @@ const PINS = {
     dependencies: {
       convex: "1.31.6",
       "@convex-dev/auth": "0.0.92",
-      "@auth/core": "0.34.3"
+      "@auth/core": "0.37.4"
     },
     devDependencies: {
       typescript: "5.9.3"

--- a/tooling/scripts/check-versions.ts
+++ b/tooling/scripts/check-versions.ts
@@ -69,7 +69,9 @@ const PINS = {
   },
   convex: {
     dependencies: {
-      convex: "1.31.6"
+      convex: "1.31.6",
+      "@convex-dev/auth": "0.0.92",
+      "@auth/core": "0.34.3"
     },
     devDependencies: {
       typescript: "5.9.3"

--- a/tooling/scripts/check-versions.ts
+++ b/tooling/scripts/check-versions.ts
@@ -108,7 +108,7 @@ for (const [dep, ver] of Object.entries(PINS.web.dependencies)) {
   assertEq(`apps/web dependency ${dep}`, webPkg.dependencies?.[dep], ver);
 }
 for (const [dep, ver] of Object.entries(PINS.web.devDependencies)) {
-  assertEq(`apps/web devDependency ${dep}`, getDep(webPkg, dep), ver);
+  assertEq(`apps/web devDependency ${dep}`, webPkg.devDependencies?.[dep], ver);
 }
 
 const apiPkg = readJSON(join(ROOT, "apps", "api", "package.json"));
@@ -116,7 +116,7 @@ for (const [dep, ver] of Object.entries(PINS.api.dependencies)) {
   assertEq(`apps/api dependency ${dep}`, apiPkg.dependencies?.[dep], ver);
 }
 for (const [dep, ver] of Object.entries(PINS.api.devDependencies)) {
-  assertEq(`apps/api devDependency ${dep}`, getDep(apiPkg, dep), ver);
+  assertEq(`apps/api devDependency ${dep}`, apiPkg.devDependencies?.[dep], ver);
 }
 
 const convexPkg = readJSON(join(ROOT, "apps", "convex", "package.json"));
@@ -124,7 +124,7 @@ for (const [dep, ver] of Object.entries(PINS.convex.dependencies)) {
   assertEq(`apps/convex dependency ${dep}`, convexPkg.dependencies?.[dep], ver);
 }
 for (const [dep, ver] of Object.entries(PINS.convex.devDependencies)) {
-  assertEq(`apps/convex devDependency ${dep}`, getDep(convexPkg, dep), ver);
+  assertEq(`apps/convex devDependency ${dep}`, convexPkg.devDependencies?.[dep], ver);
 }
 
 const configPkg = readJSON(join(ROOT, "packages", "config", "package.json"));

--- a/tooling/scripts/check-versions.ts
+++ b/tooling/scripts/check-versions.ts
@@ -74,6 +74,12 @@ const PINS = {
     devDependencies: {
       typescript: "5.9.3"
     }
+  },
+  config: {
+    dependencies: {
+      zod: "3.23.8",
+      dotenv: "16.4.7"
+    }
   }
 } as const;
 
@@ -106,6 +112,11 @@ for (const [dep, ver] of Object.entries(PINS.convex.dependencies)) {
 }
 for (const [dep, ver] of Object.entries(PINS.convex.devDependencies)) {
   assertEq(`apps/convex devDependency ${dep}`, getDep(convexPkg, dep), ver);
+}
+
+const configPkg = readJSON(join(ROOT, "packages", "config", "package.json"));
+for (const [dep, ver] of Object.entries(PINS.config.dependencies)) {
+  assertEq(`packages/config dependency ${dep}`, configPkg.dependencies?.[dep], ver);
 }
 
 console.log("✅ Version pins OK");

--- a/tooling/scripts/check-versions.ts
+++ b/tooling/scripts/check-versions.ts
@@ -52,7 +52,8 @@ const PINS = {
     dependencies: {
       next: "16.1.6",
       react: "19.2.4",
-      "react-dom": "19.2.4"
+      "react-dom": "19.2.4",
+      zod: "3.23.8"
     },
     devDependencies: {
       tailwindcss: "4.1.18",

--- a/tooling/scripts/check-versions.ts
+++ b/tooling/scripts/check-versions.ts
@@ -64,7 +64,13 @@ const PINS = {
   },
   api: {
     dependencies: {
-      elysia: "1.4.22"
+      elysia: "1.4.22",
+      "@elysiajs/cors": "1.4.2",
+      "@elysiajs/bearer": "1.4.4",
+      pino: "10.3.1"
+    },
+    devDependencies: {
+      "pino-pretty": "13.1.3"
     }
   },
   convex: {
@@ -108,6 +114,9 @@ for (const [dep, ver] of Object.entries(PINS.web.devDependencies)) {
 const apiPkg = readJSON(join(ROOT, "apps", "api", "package.json"));
 for (const [dep, ver] of Object.entries(PINS.api.dependencies)) {
   assertEq(`apps/api dependency ${dep}`, apiPkg.dependencies?.[dep], ver);
+}
+for (const [dep, ver] of Object.entries(PINS.api.devDependencies)) {
+  assertEq(`apps/api devDependency ${dep}`, getDep(apiPkg, dep), ver);
 }
 
 const convexPkg = readJSON(join(ROOT, "apps", "convex", "package.json"));

--- a/tooling/scripts/check-versions.ts
+++ b/tooling/scripts/check-versions.ts
@@ -74,7 +74,8 @@ const PINS = {
       "@auth/core": "0.37.4"
     },
     devDependencies: {
-      typescript: "5.9.3"
+      typescript: "5.9.3",
+      "convex-test": "0.0.41"
     }
   },
   config: {

--- a/tooling/scripts/check-versions.ts
+++ b/tooling/scripts/check-versions.ts
@@ -71,7 +71,8 @@ const PINS = {
     dependencies: {
       convex: "1.31.6",
       "@convex-dev/auth": "0.0.92",
-      "@auth/core": "0.37.4"
+      "@auth/core": "0.37.4",
+      stripe: "22.1.1"
     },
     devDependencies: {
       typescript: "5.9.3",


### PR DESCRIPTION
## Summary

Sub-project 1 of 6 from the `/audit composable-ai-stack` follow-up. Makes the template's defaults safe to fork by closing the Critical and High security findings from the audit and putting env validation + Convex auth in place so later sub-projects can build on a real foundation.

**Spec:** [`docs/superpowers/specs/2026-05-12-foundation-hardening-design.md`](docs/superpowers/specs/2026-05-12-foundation-hardening-design.md)
**Plan:** [`docs/superpowers/plans/2026-05-12-foundation-hardening.md`](docs/superpowers/plans/2026-05-12-foundation-hardening.md)

### What landed

- **`packages/config`** — Zod env schema (`schema.ts`, pure), Node loader (`node.ts`, `dotenv` + `Object.freeze`). NODE_ENV-conditional required-in-prod fields enforced via `superRefine`. `exports` map exposes `.` and `./schema` so Convex's deploy-time bundler and Next's Edge runtime can both resolve.
- **Convex Auth** — `@convex-dev/auth@0.0.92` + `@auth/core@0.37.4` (peer range satisfied), Password provider, `requireUser`/`requireUserDoc` guards with a `by_token` fallback so `convex-test`'s `withIdentity` injection works. Example `users.me` / `users.updateProfile`. `auth.config.ts` throws a clear error when `SITE_URL` is unset.
- **Stripe webhook (Critical fix)** — `apps/convex/convex/http.ts` was returning `200` unsigned. Now: raw body via `request.text()`, async signature verification via `stripe.webhooks.constructEventAsync` (required because Bun resolves Stripe's `"bun"` export → SubtleCrypto), idempotency via `processedStripeEvents` table + `by_event_id` index, subscription state synced to `users.planStatus` / `users.plan`. Stripe SDK `22.1.1` with `apiVersion: "2026-04-22.dahlia"`.
- **Next.js CSP** — `apps/web/middleware.ts` issues a per-request 16-byte base64 nonce, sets `x-nonce` on the request and a strict `Content-Security-Policy` with `'strict-dynamic'` on the response. Dev keeps `'unsafe-eval'` + `ws://localhost:*`; prod omits both. `apps/web/next.config.ts` adds static security headers (HSTS prod-only).
- **Elysia hardening** — `apps/api` now composes CORS (allowlisted to `NEXT_PUBLIC_APP_URL`), security-headers, structured `pino` logger with redaction, `bearerGuard` (constant-time compare), in-memory rate limiter with `X-RateLimit-Backend: memory`, `onError` mapping codes to statuses, graceful `SIGTERM`/`SIGINT` drain. Elysia named-plugin hook scope was widened to `{ as: "global" }` — a critical fix caught by smoke test (otherwise `/protected/me` would have been unguarded).
- **`.env.example`** — rewritten to match what `@acme/config` actually validates. Adds `apps/web/.env.local.example` for the `NEXT_PUBLIC_*` subset.
- **README** — adds "Scaling the rate limiter" section pointing at Upstash for multi-worker deployments.
- **Tests** — 20 total: `packages/config` (7), `apps/convex` (4 auth + 5 webhook), `apps/web` (4 CSP middleware).
- **Pins** — every new dep added to `tooling/scripts/check-versions.ts` with exact versions; no `^`/`~` anywhere.

### Out of scope (deferred to later sub-projects)

- AI runtime (`packages/prompts` loader, `packages/ai` typed tools, evals harness)
- Convex AI tables (`conversations`, `messages`, `toolCalls`, `evalRuns`, multi-tenant `workspaceId`)
- App shell + chat demo (`next-themes`, `app/chat`, loading/error states, SSE)
- Landing polish (token migration off `slate-*` literals, `next/font`, brand)
- DX cleanup (`@acme/*` → `@cas/*` rename, root `package.json` name, `exports` fields on the empty packages)

## Test Plan

- [x] `bun run typecheck` — 10/10 packages green
- [x] `bun run check:versions` — `Version pins OK`
- [x] `bun run test` — 20 passed
- [x] Manual: `/protected/me` without bearer → 401, with bearer → 200 + rate-limit headers (Task 20 smoke test commit `f61f229`)
- [x] Manual: Stripe webhook unsigned → 400, valid signature → 200 + DB write, replay → 200 + single row (covered by `http.test.ts`)
- [x] Manual: dev `/` returns CSP header with a fresh nonce per refresh (covered by `middleware.test.ts`)
- [ ] `bunx convex deploy --dry-run` — requires `CONVEX_DEPLOYMENT`; verify in your environment before merging

## Notes for the reviewer

- `apps/convex/convex/_generated/api.d.ts` was hand-edited (codegen needs a deployment). The file has a header note flagging this; next real `convex codegen` will regenerate equivalent content with formatting differences.
- `convex-test@0.0.41` pinned (newer versions need `convex@1.32+`; we pin `1.31.6`).
- `Bun` doesn't implement `import.meta.glob`, so `convex-test`'s modules map is supplied manually via `apps/convex/convex/_lib/test-modules.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full API server with bearer auth, in-memory rate limiting, security headers, structured logging, and graceful shutdown
  * Stripe webhook with signature verification, idempotent processing, and subscription status updates persisted
  * Auth endpoints for retrieving/updating user profile
  * Edge CSP middleware: per-request nonce propagation
  * Centralized environment validation and runtime env exports

* **Tests**
  * New test suites for Stripe webhooks, auth helpers, CSP middleware, and env schema

* **Documentation**
  * Foundation hardening guide and rate-limiter scaling instructions

* **Chores**
  * Release metadata added (version 0.1.0, changelog)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yabasha/composable-ai-stack/pull/9)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->